### PR TITLE
[Fix] 불필요한 파일 통합 및 icon이미지 파일 변경에 따른 수정

### DIFF
--- a/web/src/components/LikeIcon/LikeIconSpan.js
+++ b/web/src/components/LikeIcon/LikeIconSpan.js
@@ -1,4 +1,4 @@
-import { css } from 'styled-components';
+import styled, { css } from 'styled-components';
 
 const TOTAL_WIDTH = 1000;
 const TOTAL_HEIGHT = 1000;
@@ -17,11 +17,11 @@ const iconHeight = ORIGIN_ICON_HEIGHT / RATIO_HEIGHT;
 
 const backgroundStyles = css`
   background-image: url(${({ icon }) => icon});
-  background-position-x: ${iconWidth * OFFSET_WIDTH}px;
+  background-position-x: ${iconWidth * OFFSET_WIDTH - 2}px;
   background-position-y: ${({ isFill }) =>
     isFill
-      ? `${iconHeight * OFFSET_HEIGHT_OF_FILL}px`
-      : `${iconHeight * OFFSET_HEIGHT_OF_EMPTY}px`};
+      ? `${iconHeight * OFFSET_HEIGHT_OF_FILL + 1}px`
+      : `${iconHeight * OFFSET_HEIGHT_OF_EMPTY + 1}px`};
   background-size: ${backgroundWidth}px ${backgroundHeight}px;
   background-repeat: no-repeat;
 `;
@@ -34,4 +34,8 @@ const spanStyles = css`
   height: ${iconHeight}px;
 `;
 
-export default spanStyles;
+const LikeIconSpan = styled.span`
+  ${spanStyles}
+`;
+
+export default LikeIconSpan;

--- a/web/src/components/LikeIcon/StyledSpan.js
+++ b/web/src/components/LikeIcon/StyledSpan.js
@@ -1,9 +1,0 @@
-import styled from 'styled-components';
-
-import spanStyles from './SpanStyles';
-
-const StyledSpan = styled.span`
-  ${spanStyles}
-`;
-
-export default StyledSpan;

--- a/web/src/components/LikeIcon/Wrapper.js
+++ b/web/src/components/LikeIcon/Wrapper.js
@@ -1,7 +1,0 @@
-import styled from 'styled-components';
-
-const Wrapper = styled.div`
-  width: 100%;
-`;
-
-export default Wrapper;

--- a/web/src/components/LikeIcon/index.js
+++ b/web/src/components/LikeIcon/index.js
@@ -2,8 +2,7 @@ import React, { useState } from 'react';
 
 import icon from '../../images/icon-1.png';
 
-import Wrapper from './Wrapper';
-import StyledSpan from './StyledSpan';
+import LikeIconSpan from './LikeIconSpan';
 
 const LikeIcon = () => {
   const [fill, toggleFill] = useState(false);
@@ -13,9 +12,9 @@ const LikeIcon = () => {
   };
 
   return (
-    <Wrapper>
-      <StyledSpan onClick={onToggleHandler} isFill={fill} icon={icon} />
-    </Wrapper>
+    <>
+      <LikeIconSpan onClick={onToggleHandler} isFill={fill} icon={icon} />
+    </>
   );
 };
 


### PR DESCRIPTION
- icon 이미지 파일이 변경됨 따라 background-position 변경.

- Wrapper 컴포넌트는 불필요하게 div를 하나 더 생성하므로 제거.

- StyledSpan과 SpanStyles파일을 분리하는 것이  불필요하다고
판단하여 LikeIconSpan 파일로 통합.

- LikeIconSpan으로 통합됨에 따라 index.js 코드 수정.