### PR TITLE
[Fix] 비율에 따른 좋아요 이미지가 짤리는 버그 수정

### DIFF
--- a/web/src/components/LikeIcon/LikeIconSpan.js
+++ b/web/src/components/LikeIcon/LikeIconSpan.js
@@ -2,27 +2,19 @@ import styled, { css } from 'styled-components';
 
 const TOTAL_WIDTH = 1000;
 const TOTAL_HEIGHT = 1000;
-const ORIGIN_ICON_WIDTH = 125;
-const ORIGIN_ICON_HEIGHT = 125;
-const OFFSET_WIDTH = -1;
-const OFFSET_HEIGHT_OF_EMPTY = -2;
-const OFFSET_HEIGHT_OF_FILL = -3;
-const RATIO_WIDTH = 3;
-const RATIO_HEIGHT = 3;
-
-const backgroundWidth = TOTAL_WIDTH / RATIO_WIDTH;
-const backgroundHeight = TOTAL_HEIGHT / RATIO_HEIGHT;
-const iconWidth = ORIGIN_ICON_WIDTH / RATIO_WIDTH;
-const iconHeight = ORIGIN_ICON_HEIGHT / RATIO_HEIGHT;
+const ICON_WIDTH = 125;
+const ICON_HEIGHT = 125;
+const ICON_POS_X = -130;
+const EMPTY_ICON_POS_Y = -245;
+const FILL_ICON_POS_Y = -375;
 
 const backgroundStyles = css`
   background-image: url(${({ icon }) => icon});
-  background-position-x: ${iconWidth * OFFSET_WIDTH - 2}px;
-  background-position-y: ${({ isFill }) =>
-    isFill
-      ? `${iconHeight * OFFSET_HEIGHT_OF_FILL + 1}px`
-      : `${iconHeight * OFFSET_HEIGHT_OF_EMPTY + 3}px`};
-  background-size: ${backgroundWidth}px ${backgroundHeight}px;
+  background-position-x: ${({ ratio }) => ICON_POS_X / ratio}px;
+  background-position-y: ${({ isFill, ratio }) =>
+    isFill ? `${FILL_ICON_POS_Y / ratio}px` : `${EMPTY_ICON_POS_Y / ratio}px`};
+  background-size: ${({ ratio }) =>
+    `${TOTAL_WIDTH / ratio}px ${TOTAL_HEIGHT / ratio}px`};
   background-repeat: no-repeat;
 `;
 
@@ -30,8 +22,8 @@ const spanStyles = css`
   ${backgroundStyles};
 
   display: inline-block;
-  width: ${iconWidth}px;
-  height: ${iconHeight}px;
+  width: ${({ ratio }) => ICON_WIDTH / ratio}px;
+  height: ${({ ratio }) => ICON_HEIGHT / ratio}px;
 `;
 
 const LikeIconSpan = styled.span`

--- a/web/src/components/LikeIcon/LikeIconSpan.js
+++ b/web/src/components/LikeIcon/LikeIconSpan.js
@@ -1,33 +1,47 @@
 import styled, { css } from 'styled-components';
 
-const TOTAL_WIDTH = 1000;
-const TOTAL_HEIGHT = 1000;
-const ICON_WIDTH = 125;
-const ICON_HEIGHT = 125;
+const TOTAL_LENGTH = 1000;
+const ICON_LENGTH = 125;
 const ICON_POS_X = -130;
 const EMPTY_ICON_POS_Y = -245;
 const FILL_ICON_POS_Y = -375;
 
 const backgroundStyles = css`
-  background-image: url(${({ icon }) => icon});
-  background-position-x: ${({ ratio }) => ICON_POS_X / ratio}px;
-  background-position-y: ${({ isFill, ratio }) =>
-    isFill ? `${FILL_ICON_POS_Y / ratio}px` : `${EMPTY_ICON_POS_Y / ratio}px`};
-  background-size: ${({ ratio }) =>
-    `${TOTAL_WIDTH / ratio}px ${TOTAL_HEIGHT / ratio}px`};
   background-repeat: no-repeat;
+
+  ${({ icon, isFill, ratio }) => {
+    const bgSize = TOTAL_LENGTH / ratio;
+    return css`
+      background-image: url(${icon});
+      background-size: ${bgSize}px ${bgSize}px;
+      background-position-x: ${ICON_POS_X / ratio}px;
+      background-position-y: ${isFill
+        ? `${FILL_ICON_POS_Y / ratio}px`
+        : `${EMPTY_ICON_POS_Y / ratio}px`};
+    `;
+  }}
 `;
 
 const spanStyles = css`
-  ${backgroundStyles};
-
   display: inline-block;
-  width: ${({ ratio }) => ICON_WIDTH / ratio}px;
-  height: ${({ ratio }) => ICON_HEIGHT / ratio}px;
+
+  ${({ ratio }) => {
+    const length = ICON_LENGTH / ratio;
+    return css`
+      width: ${length}px;
+      height: ${length}px;
+    `;
+  }}
 `;
 
 const LikeIconSpan = styled.span`
+  ${backgroundStyles};
   ${spanStyles}
 `;
+
+LikeIconSpan.defaultProps = {
+  ratio: 1,
+  isFill: false,
+};
 
 export default LikeIconSpan;

--- a/web/src/components/LikeIcon/index.js
+++ b/web/src/components/LikeIcon/index.js
@@ -4,7 +4,7 @@ import icon from '../../images/icon-1.png';
 
 import LikeIconSpan from './LikeIconSpan';
 
-const LikeIcon = () => {
+const LikeIcon = ({ ratio }) => {
   const [fill, toggleFill] = useState(false);
 
   const onToggleHandler = () => {
@@ -13,7 +13,12 @@ const LikeIcon = () => {
 
   return (
     <>
-      <LikeIconSpan onClick={onToggleHandler} isFill={fill} icon={icon} />
+      <LikeIconSpan
+        onClick={onToggleHandler}
+        isFill={fill}
+        icon={icon}
+        ratio={ratio}
+      />
     </>
   );
 };

--- a/web/src/components/LikeIcon/index.js
+++ b/web/src/components/LikeIcon/index.js
@@ -5,17 +5,17 @@ import icon from '../../images/icon-1.png';
 import LikeIconSpan from './LikeIconSpan';
 
 const LikeIcon = ({ ratio }) => {
-  const [fill, toggleFill] = useState(false);
+  const [isFill, onToggle] = useState(false);
 
   const onToggleHandler = () => {
-    toggleFill(!fill);
+    onToggle(!isFill);
   };
 
   return (
     <>
       <LikeIconSpan
         onClick={onToggleHandler}
-        isFill={fill}
+        isFill={isFill}
         icon={icon}
         ratio={ratio}
       />


### PR DESCRIPTION
ratio 값에 따라서 좋아요의 하트 이미지가 짤리는 현상을
고치기 위해 background image의 size와 position 값을 계산하는
방식과 이미지 span의 width, height 값을 계산하는 방식을 수정.