### PR TITLE
[남정호] w3_리뷰요청_댓글 컴포넌트 및 게시물 제목 컴포넌트

### DIFF
--- a/Comment/CommentWrapper.js
+++ b/Comment/CommentWrapper.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+const CommentWrapper = styled.li`
+  display: flex;
+  list-style-type: none;
+  width: 100%;
+  padding: 12px 16px 0px 16px;
+  box-sizing: border-box;
+  & + & {
+    margin-top: 16px;
+  }
+  h3 {
+    font-weight: 600;
+    display: inline;
+    margin-right: 5px;
+  }
+  article {
+    display: inline;
+  }
+`;
+
+export default CommentWrapper;

--- a/Comment/Content/ContentWrapper.js
+++ b/Comment/Content/ContentWrapper.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const ContentWrapper = styled.section`
+  font-size: 14px;
+  main {
+    margin-bottom: 16px;
+  }
+`;
+
+export default ContentWrapper;

--- a/Comment/Content/GrayButton.js
+++ b/Comment/Content/GrayButton.js
@@ -1,0 +1,18 @@
+import styled, { css } from 'styled-components';
+
+const GrayButton = styled.button`
+  ${({ theme }) => css`
+    color: ${theme.palette.gray_font};
+    background: 0 0;
+    border: 0;
+    cursor: pointer;
+    display: inline;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 14px;
+    margin-right: 16px;
+    padding: 0;
+  `}
+`;
+
+export default GrayButton;

--- a/Comment/Content/UpdatedTime.js
+++ b/Comment/Content/UpdatedTime.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const UpdatedTime = styled.time`
+  color: ${({ theme }) => theme.palette.gray_font};
+  font-size: 15px;
+  font-weight: 400;
+  margin-right: 16px;
+`;
+
+export default UpdatedTime;

--- a/Comment/Content/index.js
+++ b/Comment/Content/index.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { ContentWrapper, UpdatedTime, GrayButton } from './styles';
+import StyledLink from '../../StyledLink';
+
+function Content({ user, content, likerCount }) {
+  return (
+    <ContentWrapper>
+      <main>
+        <h3>
+          <StyledLink
+            to={`/${user.username}`}
+            style={{ display: 'inline-block' }}
+          >
+            {user.username}
+          </StyledLink>
+        </h3>
+        <article>{content}</article>
+      </main>
+      <UpdatedTime>5h</UpdatedTime>
+      <GrayButton>{likerCount} like</GrayButton>
+      <GrayButton>Reply</GrayButton>
+    </ContentWrapper>
+  );
+}
+
+export default Content;

--- a/Comment/Content/styles.js
+++ b/Comment/Content/styles.js
@@ -1,0 +1,5 @@
+import ContentWrapper from './ContentWrapper';
+import UpdatedTime from './UpdatedTime';
+import GrayButton from './GrayButton';
+
+export { ContentWrapper, UpdatedTime, GrayButton };

--- a/Comment/LikeIconWrapper.js
+++ b/Comment/LikeIconWrapper.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const LikeIconWrapper = styled.div`
+  margin-top: 10px;
+`;
+
+export default LikeIconWrapper;

--- a/Comment/ProfileWrapper.js
+++ b/Comment/ProfileWrapper.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const ProfileWrapper = styled.div`
+  margin-right: 18px;
+`;
+
+export default ProfileWrapper;

--- a/Comment/index.js
+++ b/Comment/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { CommentWrapper, ProfileWrapper, LikeIconWrapper } from './styles';
+import ProfileIcon from '../ProfileIcon';
+import LikeIcon from '../LikeIcon';
+import Content from './Content';
+
+const Comment = ({ user, content, updatedAt, likerCount, commentId }) => {
+  return (
+    <CommentWrapper>
+      <ProfileWrapper>
+        <ProfileIcon />
+      </ProfileWrapper>
+      <Content content={content} user={user} likerCount={likerCount} />
+      <LikeIconWrapper>
+        <LikeIcon ratio={10} />
+      </LikeIconWrapper>
+    </CommentWrapper>
+  );
+};
+
+export default Comment;

--- a/Comment/styles.js
+++ b/Comment/styles.js
@@ -1,0 +1,5 @@
+import CommentWrapper from './CommentWrapper';
+import LikeIconWrapper from './LikeIconWrapper';
+import ProfileWrapper from './ProfileWrapper';
+
+export { CommentWrapper, LikeIconWrapper, ProfileWrapper };

--- a/PostText/CommentWrapper.js
+++ b/PostText/CommentWrapper.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+const CommentWrapper = styled.li`
+  display: flex;
+  list-style-type: none;
+  width: 100%;
+  padding: 12px 16px 0px 16px;
+  box-sizing: border-box;
+  & + & {
+    margin-top: 16px;
+  }
+  h3 {
+    font-weight: 600;
+    display: inline;
+    margin-right: 5px;
+  }
+  article {
+    display: inline;
+  }
+`;
+
+export default CommentWrapper;

--- a/PostText/Content/ContentWrapper.js
+++ b/PostText/Content/ContentWrapper.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const ContentWrapper = styled.section`
+  font-size: 14px;
+  main {
+    margin-bottom: 16px;
+  }
+`;
+
+export default ContentWrapper;

--- a/PostText/Content/StyledTime.js
+++ b/PostText/Content/StyledTime.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const StyledTime = styled.time`
+  color: ${({ theme }) => theme.palette.gray_font};
+  font-size: 15px;
+  font-weight: 400;
+  margin-right: 16px;
+`;
+
+export default StyledTime;

--- a/PostText/Content/index.js
+++ b/PostText/Content/index.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { ContentWrapper, StyledTime } from './styles';
+import StyledLink from '../../../../../../components/StyledLink';
+
+function Content({ user, content, likerCount }) {
+  return (
+    <ContentWrapper>
+      <main>
+        <h3>
+          <StyledLink
+            to={`/${user.username}`}
+            style={{ display: 'inline-block' }}
+          >
+            {user.username}
+          </StyledLink>
+        </h3>
+        <article>{content}</article>
+      </main>
+      <StyledTime>5h</StyledTime>
+    </ContentWrapper>
+  );
+}
+
+export default Content;

--- a/PostText/Content/styles.js
+++ b/PostText/Content/styles.js
@@ -1,0 +1,4 @@
+import ContentWrapper from './ContentWrapper';
+import StyledTime from './StyledTime';
+
+export { ContentWrapper, StyledTime };

--- a/PostText/ProfileWrapper.js
+++ b/PostText/ProfileWrapper.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const ProfileWrapper = styled.div`
+  margin-right: 18px;
+`;
+
+export default ProfileWrapper;

--- a/PostText/index.js
+++ b/PostText/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { CommentWrapper, ProfileWrapper } from './styles';
+import ProfileIcon from '../../../../../components/ProfileIcon';
+import Content from './Content';
+
+const Comment = ({ user, content, updatedAt, likerCount, commentId }) => {
+  return (
+    <CommentWrapper>
+      <ProfileWrapper>
+        <ProfileIcon />
+      </ProfileWrapper>
+      <Content content={content} user={user} likerCount={likerCount} />
+    </CommentWrapper>
+  );
+};
+
+export default Comment;

--- a/PostText/styles.js
+++ b/PostText/styles.js
@@ -1,0 +1,4 @@
+import CommentWrapper from './CommentWrapper';
+import ProfileWrapper from './ProfileWrapper';
+
+export { CommentWrapper, ProfileWrapper };


### PR DESCRIPTION
![제목 없음](https://user-images.githubusercontent.com/40619551/69394119-61d8ce80-0d1e-11ea-8279-8118db0a11fd.png)

### 기능
- PostText: 포스트의 내용이 담긴 컴포넌트
- Comment: 댓글 컴포넌트

### 개발 상황
PostText와 Comment  컴포넌트를 각각 별개의 컴포넌트로 제작한 상황입니다.

### 질문
두 컴포넌트가 기능상 매우 흡사한데, PostText는 `좋아요 개수`, `답글 달기`, `좋아요 버튼`이 빠져 있습니다. 두 컴포넌트의 공통적인 기능을 하나의 컴포넌트로 만들어서 관리하면, 코드 관리가 편해지지만, 가독성이 떨어집니다. 반면, 두 컴포넌트를 분리하여 만들면, 수정을 할 때에 두번 수정해야 한다는 단점이 있지만, 기능상 확실히 분리가 되기 때문에 가독성은 높아집니다.  
이와 비슷한 상황이 개발 전반적으로 계속 발생하는데, 어떠한 전략을 취하는게 좋을지 궁금합니다!