### PR TITLE
[정소영] w3_리뷰요청_검색 기능 구현

### DIFF
--- a/Navigation/Search/SearchToolTip/SearchResult/index.js
+++ b/Navigation/Search/SearchToolTip/SearchResult/index.js
@@ -1,14 +1,21 @@
-import React from 'react';
-import ProfileIcon from '../../../../../components/ProfileIcon';
-import { SearchResultWrapper, ResultInfo } from './styles';
+import React from "react";
+import ProfileIcon from "../../../../../components/ProfileIcon";
+import { SearchResultWrapper, ResultInfo } from "./styles";
 
 const SearchResult = ({ result }) => {
-  const imgSrc = result.type === 'user' ? undefined : 'hashtag.png';
-  const id = result.type === 'user' ? result.username : `# ${result.name}`;
-  const option =
-    result.type === 'user' ? (
-      <span className="option">{result.name}</span>
-    ) : null;
+  let imgSrc;
+  let content;
+  let option;
+
+  if (result.type === "user") {
+    imgSrc = undefined;
+    content = result.username;
+    option = <span className="option">{result.name}</span>;
+  } else {
+    imgSrc = "hashtag.png";
+    content = `# ${result.name}`;
+    option = null;
+  }
 
   return (
     <SearchResultWrapper>
@@ -16,7 +23,7 @@ const SearchResult = ({ result }) => {
         <ProfileIcon imgSrc={imgSrc} />
       </div>
       <ResultInfo>
-        <span>{id}</span>
+        <span>{content}</span>
         {option}
       </ResultInfo>
     </SearchResultWrapper>

--- a/Navigation/Search/SearchToolTip/SearchResult/index.js
+++ b/Navigation/Search/SearchToolTip/SearchResult/index.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import ProfileIcon from '../../../../../components/ProfileIcon';
+import { SearchResultWrapper, ResultInfo } from './styles';
+
+const SearchResult = ({ result }) => {
+  const imgSrc = result.type === 'user' ? undefined : 'hashtag.png';
+  const id = result.type === 'user' ? result.username : `# ${result.name}`;
+  const option =
+    result.type === 'user' ? (
+      <span className="option">{result.name}</span>
+    ) : null;
+
+  return (
+    <SearchResultWrapper>
+      <div>
+        <ProfileIcon imgSrc={imgSrc} />
+      </div>
+      <ResultInfo>
+        <span>{id}</span>
+        {option}
+      </ResultInfo>
+    </SearchResultWrapper>
+  );
+};
+
+export default SearchResult;

--- a/Navigation/Search/SearchToolTip/SearchResultList.js
+++ b/Navigation/Search/SearchToolTip/SearchResultList.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import SearchResult from './SearchResult';
+
+const SearchResultList = props => {
+  const { searchResults } = props;
+  const renderedSearchResults = searchResults.map((result, index) => {
+    return <SearchResult key={index} result={result} />;
+  });
+  return <div>{renderedSearchResults}</div>;
+};
+
+export default SearchResultList;

--- a/Navigation/Search/SearchToolTip/SearchResultList.js
+++ b/Navigation/Search/SearchToolTip/SearchResultList.js
@@ -1,8 +1,7 @@
-import React from 'react';
-import SearchResult from './SearchResult';
+import React from "react";
+import SearchResult from "./SearchResult";
 
-const SearchResultList = props => {
-  const { searchResults } = props;
+const SearchResultList = ({ searchResults }) => {
   const renderedSearchResults = searchResults.map((result, index) => {
     return <SearchResult key={index} result={result} />;
   });

--- a/Navigation/Search/SearchToolTip/index.js
+++ b/Navigation/Search/SearchToolTip/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { SearchToolTipWrapper } from './styles';
+import SearchResultList from './SearchResultList';
+
+const SearchToolTip = ({ isVisible, searchResults }) => {
+  if (!isVisible) return null;
+  return (
+    <SearchToolTipWrapper>
+      <SearchResultList searchResults={searchResults} />
+    </SearchToolTipWrapper>
+  );
+};
+
+export default SearchToolTip;

--- a/Navigation/Search/index.js
+++ b/Navigation/Search/index.js
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { SearchWrapper, Input } from './styles';
+import Icon from '../../../components/Icon';
+import SearchToolTip from './SearchToolTip';
+
+const Search = () => {
+  const [inputValue, setInputValue] = useState('');
+  const [isVisible, setIsVisible] = useState(false);
+  const [searchResults, setSearchResults] = useState([]);
+
+  const clickClear = () => {
+    setInputValue('');
+  };
+
+  const onChange = async e => {
+    setInputValue(e.target.value);
+    if (e.target.value === '') {
+      setIsVisible(false);
+      return;
+    }
+
+    const searchQuery = `{
+      searchUser(id: "${e.target.value}"){
+        type
+        username
+        name
+        profileImage
+      }
+      searchHashtag(id: "${e.target.value}") {
+        type
+        name
+      }
+    }`;
+
+    const resultsResponse = await fetch('http://localhost:3000/graphql', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ query: searchQuery }),
+    });
+    const resultResponseJson = await resultsResponse.json();
+
+    // resultResponseJson에 여러개의 배열을 하나로 합친다.
+    let results = [];
+    Object.keys(resultResponseJson.data).map(element => {
+      results = results.concat(resultResponseJson.data[element]);
+    });
+
+    if (results.length === 0) {
+      setIsVisible(false);
+      return;
+    }
+
+    results.sort(() => {
+      return Math.random() - Math.random();
+    });
+    setSearchResults(results);
+
+    setIsVisible(true);
+  };
+
+  return (
+    <SearchWrapper>
+      <Input placeholder="검색" value={inputValue} onChange={onChange} />
+      <SearchToolTip isVisible={isVisible} searchResults={searchResults} />
+      <Icon
+        ratio={10}
+        posX={-260}
+        posY={-625}
+        style={{ marginTop: '2px', position: 'absolute' }}
+      />
+      <Icon
+        ratio={10}
+        posX={-390}
+        posY={-625}
+        onClick={clickClear}
+        style={{ marginTop: '2px' }}
+      />
+    </SearchWrapper>
+  );
+};
+
+export default Search;

--- a/Navigation/index.js
+++ b/Navigation/index.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import Search from './Search';
+import Icon from '../../components/Icon';
+import ProfileIcon from '../../components/ProfileIcon';
+import StyledLink from '../../components/StyledLink';
+import { NavBackground, NavItemGroup } from './styles';
+
+const Navigation = ({ myInfo }) => {
+  return (
+    <>
+      <NavBackground>
+        <NavItemGroup>
+          <StyledLink to="/" style={{ display: 'flex', alignItems: 'center' }}>
+            <Icon ratio={6} posX={0} posY={-505} />
+            <Icon
+              ratio={6}
+              posX={0}
+              posY={0}
+              style={{ width: '170px', height: '39px', marginTop: '18px' }}
+            />
+          </StyledLink>
+        </NavItemGroup>
+        <NavItemGroup>
+          <Search />
+        </NavItemGroup>
+        <NavItemGroup>
+          <StyledLink to="/nowpost">
+            <Icon ratio={5} posX={-260} posY={-245} />
+          </StyledLink>
+          <Icon
+            ratio={6}
+            posX={-130}
+            posY={-246}
+            style={{ marginTop: '1px' }}
+          />
+          <Icon
+            ratio={5}
+            posX={-130}
+            posY={-500}
+            style={{ marginTop: '7px' }}
+          />
+          <StyledLink to={`/${myInfo.username}`}>
+            <ProfileIcon ratio={8} />
+          </StyledLink>
+        </NavItemGroup>
+      </NavBackground>
+    </>
+  );
+};
+
+export default Navigation;


### PR DESCRIPTION
### 기능
input value가 바뀔 때마다 fetch 요청을 해서 검색결과를 응답해서 tooltip에 결과를 보여줌.

### 개발 상황
Search/index.js 에서 input이 onChange될 때마다 value를 검사하고 fetch 요청.
응답 결과를 재구성해서 SearchToolTip/index.js -> SearchTooltop/SearchResultList.js 에 보냄.
SearchResultList.js에서 SearchResult를 하나씩 생성해서 tooltip 생성.

### 질문
1. Search/index.js에서 input이 onChage될 때마다 응답 결과를 재구성해서 props로 내려주는데
이 재구성하는 로직을 back에서 해주는게 좋을지? 아니면 응답 결과를 props로 일단 내려준 다음에
SearchToolTip/index.js 여기서 재구성해주는게 좋을지??
2. Search/index.js의 query문은 빼주는게 좋을 것 같은데 보통 Search에 필요한 query문을 해당 폴더 안에 모아 놓는지 모든 page의 query문을 모아놓는 폴더를 만드는지??