### PR TITLE
[Fix] sequelize post model 수정

### DIFF
--- a/api-server/api/models/post.js
+++ b/api-server/api/models/post.js
@@ -1,4 +1,3 @@
-'use strict';
 module.exports = (sequelize, DataTypes) => {
   const Post = sequelize.define('Post', {
     id: {
@@ -8,7 +7,7 @@ module.exports = (sequelize, DataTypes) => {
       autoIncrement: true,
     },
     postURL: {
-      type: Sequelize.STRING(2048),
+      type: DataTypes.STRING(2048),
     },
     imageUrl: {
       allowNull: true,


### PR DESCRIPTION
post model에 새로 추가된 column의 datatype이 잘못 설정되어
api-server가 실행되지 않아 수정.