### PR TITLE
[Fix] PostCardList margin-left 버그 수정

### DIFF
--- a/web/src/components/PostCardList/PostCardLine/PostCard/MarginalPostCard.js
+++ b/web/src/components/PostCardList/PostCardLine/PostCard/MarginalPostCard.js
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 
 const MarginalPostCard = styled.div`
+  margin-right: 28px;
   &:last-child {
-    margin-right: 28px;
+    margin-right: 0px;
   }
 `;
 


### PR DESCRIPTION
PostCardLine에서 마지막 카드만 margin-left가 적용되고 나머지는
적용이 안되던 것을 마지막 카드만 적용이 안되고 나머지 카드는
적용되도록 변경.