### PR TITLE
[Refact] 검색 기능 리팩토링

### DIFF
--- a/api-server/api/graphql/queries/SearchHashtagQuery.js
+++ b/api-server/api/graphql/queries/SearchHashtagQuery.js
@@ -13,6 +13,7 @@ const searchHashtagQuery = {
   resolve: (hashtag, args) => {
     return HashTag.findAll({
       where: { name: { [Op.like]: `%${args.id}%` } },
+      limit: 10,
     });
   },
 };

--- a/api-server/api/graphql/queries/SearchUserQuery.js
+++ b/api-server/api/graphql/queries/SearchUserQuery.js
@@ -18,6 +18,7 @@ const searchUserQuery = {
           { name: { [Op.like]: `%${args.id}%` } },
         ],
       },
+      limit: 10,
     });
   },
 };

--- a/web/src/components/ToolTip/ToolTipArrow.js
+++ b/web/src/components/ToolTip/ToolTipArrow.js
@@ -12,7 +12,7 @@ const ToolTipArrow = styled.div`
   transform: rotate(45deg);
   width: 14px;
   height: 14px;
-  z-index: 3;
+  z-index: 203;
   position: relative;
   left: 50%;
   bottom: 8px;

--- a/web/src/components/ToolTip/ToolTipBackground.js
+++ b/web/src/components/ToolTip/ToolTipBackground.js
@@ -6,6 +6,7 @@ const ToolTipBackground = styled.div`
   top: 0;
   width: 100%;
   height: 100%;
+  z-index: 100;
 `;
 
 export default ToolTipBackground;

--- a/web/src/components/ToolTip/ToolTipBody.js
+++ b/web/src/components/ToolTip/ToolTipBody.js
@@ -9,7 +9,7 @@ const ToolTipBody = styled.div`
     `;
   }}
   border-radius: 5px;
-  z-index: 1;
+  z-index: 200;
   max-height: 400px;
   overflow-y: scroll;
 `;

--- a/web/src/containers/Navigation/Alarm/AlarmToolTip/AlarmNoResult.js
+++ b/web/src/containers/Navigation/Alarm/AlarmToolTip/AlarmNoResult.js
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 import AlarmResultWrapper from './AlarmResult/AlarmResultWrapper';
 
-const AlarmToolTipWrapper = styled(AlarmResultWrapper)`
+const AlarmNoResult = styled(AlarmResultWrapper)`
   font-size: 0.8em;
   text-align: center;
   display: block;
 `;
 
-export default AlarmToolTipWrapper;
+export default AlarmNoResult;

--- a/web/src/containers/Navigation/Search/Input.js
+++ b/web/src/containers/Navigation/Search/Input.js
@@ -2,10 +2,12 @@ import styled from 'styled-components';
 
 const Input = styled.input.attrs({
   type: 'text',
+  placeholder: '검색',
 })`
   border: none;
   outline: none;
   margin-left: 20px;
+  z-index: 200;
 `;
 
 export default Input;

--- a/web/src/containers/Navigation/Search/SearchToolTip/SearchNoResult.js
+++ b/web/src/containers/Navigation/Search/SearchToolTip/SearchNoResult.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+const SearchNoResult = styled.div`
+  font-size: 0.8em;
+  text-align: center;
+  color: ${({ theme }) => theme.palette.gray_font};
+  padding: 20px;
+  width: 250px;
+`;
+
+export default SearchNoResult;

--- a/web/src/containers/Navigation/Search/SearchToolTip/SearchResult/ResultInfo.js
+++ b/web/src/containers/Navigation/Search/SearchToolTip/SearchResult/ResultInfo.js
@@ -9,7 +9,7 @@ const ResultInfo = styled.div`
   .option {
     margin-top: 2px;
     font-size: 0.8em;
-    color: gray;
+    color: ${({ theme }) => theme.palette.gray_font};
   }
 `;
 

--- a/web/src/containers/Navigation/Search/SearchToolTip/SearchResult/SearchResultWrapper.js
+++ b/web/src/containers/Navigation/Search/SearchToolTip/SearchResult/SearchResultWrapper.js
@@ -4,7 +4,8 @@ const SearchResultWrapper = styled.div`
   display: flex;
   flex-direction: row;
   padding: 20px;
-  border-bottom: ${({ isLast }) => (isLast ? 'none' : `1px solid lightgray`)};
+  border-bottom: ${({ theme, isLast }) =>
+    isLast ? 'none' : `1px solid ${theme.palette.border}`};
   width: 250px;
 `;
 

--- a/web/src/containers/Navigation/Search/SearchToolTip/SearchResult/index.js
+++ b/web/src/containers/Navigation/Search/SearchToolTip/SearchResult/index.js
@@ -1,23 +1,38 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import ProfileIcon from '../../../../../components/ProfileIcon';
 import { SearchResultWrapper, ResultInfo } from './styles';
 
 const SearchResult = ({ result, isLast }) => {
-  const imgSrc = result.type === 'user' ? undefined : 'hashtag.png';
-  const id = result.type === 'user' ? result.username : `# ${result.name}`;
-  const option =
-    result.type === 'user' ? (
-      <span className="option">{result.name}</span>
-    ) : null;
+  const [resultInfo, setResultInfo] = useState({
+    imgSrc: null,
+    content: null,
+    option: null,
+  });
+
+  useEffect(() => {
+    if (result.type === 'user') {
+      setResultInfo({
+        imgSrc: undefined, // 나중에 user.profileImage로 변경
+        content: result.username,
+        option: <span className="option">{result.name}</span>,
+      });
+    } else {
+      setResultInfo({
+        imgSrc: 'hashtag.png',
+        content: `# ${result.name}`,
+        option: null,
+      });
+    }
+  }, [result, setResultInfo]);
 
   return (
     <SearchResultWrapper isLast={isLast}>
       <div>
-        <ProfileIcon imgSrc={imgSrc} />
+        <ProfileIcon imgSrc={resultInfo.imgSrc} />
       </div>
       <ResultInfo>
-        <span>{id}</span>
-        {option}
+        <span>{resultInfo.content}</span>
+        {resultInfo.option}
       </ResultInfo>
     </SearchResultWrapper>
   );

--- a/web/src/containers/Navigation/Search/SearchToolTip/SearchToolTipWrapper.js
+++ b/web/src/containers/Navigation/Search/SearchToolTip/SearchToolTipWrapper.js
@@ -5,7 +5,7 @@ const SearchToolTipWrapper = styled(ToolTip)`
   justify-content: center;
   position: absolute;
   top: 53px;
-  left: -60px;
+  left: -24%;
 `;
 
 export default SearchToolTipWrapper;

--- a/web/src/containers/Navigation/Search/SearchToolTip/index.js
+++ b/web/src/containers/Navigation/Search/SearchToolTip/index.js
@@ -1,13 +1,22 @@
 import React from 'react';
-import { SearchToolTipWrapper } from './styles';
+import { SearchToolTipWrapper, SearchNoResult } from './styles';
 import SearchResultList from './SearchResultList';
 
-const SearchToolTip = ({ isVisible, setIsVisible, searchResults }) => {
+const SearchToolTip = ({ isVisible, searchDispatch, searchResults }) => {
   const clickClose = () => {
-    setIsVisible(false);
+    searchDispatch({ type: 'CLOSE_TOOLTIP' });
   };
 
   if (!isVisible) return null;
+  if (searchResults.length === 0) {
+    return (
+      <SearchToolTipWrapper onClick={clickClose}>
+        <SearchNoResult>
+          <span>검색 결과가 없습니다.</span>
+        </SearchNoResult>
+      </SearchToolTipWrapper>
+    );
+  }
   return (
     <SearchToolTipWrapper onClick={clickClose}>
       <SearchResultList searchResults={searchResults} />

--- a/web/src/containers/Navigation/Search/SearchToolTip/styles.js
+++ b/web/src/containers/Navigation/Search/SearchToolTip/styles.js
@@ -1,3 +1,4 @@
 import SearchToolTipWrapper from './SearchToolTipWrapper';
+import SearchNoResult from './SearchNoResult';
 
-export { SearchToolTipWrapper };
+export { SearchToolTipWrapper, SearchNoResult };

--- a/web/src/query/navigationQuery.js
+++ b/web/src/query/navigationQuery.js
@@ -16,4 +16,19 @@ const alarmQuery = username => {
     `;
 };
 
-module.exports = { alarmQuery };
+const searchQuery = value => {
+  return `{
+    searchUser(id: "${value}"){
+      type
+      username
+      name
+      profileImage
+    }
+    searchHashtag(id: "${value}") {
+      type
+      name
+    }
+  }`;
+};
+
+module.exports = { alarmQuery, searchQuery };


### PR DESCRIPTION
1. 검색결과가 없을시 검색 결과가 없다는 응답 툴팁에 보여주도록 수정.
2. fetch를 새로운 useFetch 사용하도록 리팩토링.
3. SearchResult component의 result를 state관리 형태로 변경.
4. 랜덤 정렬 부분 목적을 명확히 표시하기 위해 함수화.
5. 3개 이상의  state를 reducer로 관리하도록 리팩토링.
6. css관련 색상 palette에 있는 색상으로 변경.
7. 검색 결과 데이터 최대 20 응답하도록 수정.
8. 최초 마운트시 useEffect 실행되지 않도록 수정.