### PR TITLE
[Fix] 사용자 페이지간 이동 시 PostCardList 최신화

### DIFF
--- a/web/src/containers/UserPage/index.js
+++ b/web/src/containers/UserPage/index.js
@@ -21,7 +21,7 @@ const UserPage = ({ match }) => {
   useEffect(() => {
     fetchData(postCardURL);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [postCardURL]);
   const { loading, data, error } = state;
   if (loading) return <div>로딩중..</div>;
   if (error) return <div>에러가 발생했습니다</div>;


### PR DESCRIPTION
사용자 페이지간 이동 시 PostCardList가 최신화되지 않는 버그 발생.
useEffect함수의 deps에 postCardURL을 추가하여 url변경 시(즉, 다른
유저 페이지로 이동 시) PostCardList가 최신화 되도록 변경.
Close #200