### PR TITLE
[Fix] 새게시물 사진 crop 확대되어 되는 부분 수정

### DIFF
--- a/web/src/containers/NewPostPage/index.js
+++ b/web/src/containers/NewPostPage/index.js
@@ -117,9 +117,12 @@ const NewPostPage = () => {
     } catch (e) {}
   }, [setSuccess, state]);
 
-  const onCropComplete = useCallback(currentcroppedAreaPixels => {
-    dispatch({ type: 'INPUT_CROPPED_AREA', value: currentcroppedAreaPixels });
-  }, []);
+  const onCropComplete = useCallback(
+    (croppedArea, currentcroppedAreaPixels) => {
+      dispatch({ type: 'INPUT_CROPPED_AREA', value: currentcroppedAreaPixels });
+    },
+    [],
+  );
 
   const changeContent = e => {
     dispatch({ type: 'INPUT_CONTENT', value: e.target.value });


### PR DESCRIPTION
새게시물의 사진을 crop할 때 파라미터를 잘못 입력하여 확대되어
crop되고 저장되는 부분 파라미터 수정으로 오류 수정.