### PR TITLE
[Fix] 네비게이션 프로필 아이콘에 로그인한 유저 사진으로 교체

### DIFF
--- a/web/src/containers/Navigation/index.js
+++ b/web/src/containers/Navigation/index.js
@@ -41,7 +41,7 @@ const Navigation = ({ myInfo }) => {
             style={{ marginTop: '7px' }}
           />
           <StyledLink to={`/${myInfo.username}`}>
-            <ProfileIcon ratio={8} />
+            <ProfileIcon imageURL={myInfo.profileImage} ratio={8} />
           </StyledLink>
         </NavItemGroup>
       </NavBackground>


### PR DESCRIPTION
네비게이션 프로필 아이콘이 무조건 default로 나오게 되어있어
로그인한 유저 사진으로 교체

closed #96