### PR TITLE
[Fix] 좋아요 문구 버그 수정

### DIFF
--- a/web/src/components/LikeIcon/index.js
+++ b/web/src/components/LikeIcon/index.js
@@ -15,7 +15,7 @@ import {
   INCREASE_LIKE,
 } from '../LikeInfo/Context/LikerInfoContext';
 
-const LikeIcon = forwardRef(({ ratio, style }, ref) => {
+const LikeIcon = forwardRef(({ myInfo, ratio, style }, ref) => {
   const isLike = useLikeState();
   const likeDispatch = useLikeDispatch();
   const likerInfoDispatch = useLikerInfoDispatch();
@@ -25,7 +25,7 @@ const LikeIcon = forwardRef(({ ratio, style }, ref) => {
 
     if (!likerInfoDispatch) return;
     const likerListActionType = isLike ? DECREASE_LIKE : INCREASE_LIKE;
-    likerInfoDispatch({ type: likerListActionType });
+    likerInfoDispatch({ type: likerListActionType, myInfo });
   };
 
   return (

--- a/web/src/components/LikeInfo/Context/LikerInfoContext.js
+++ b/web/src/components/LikeInfo/Context/LikerInfoContext.js
@@ -4,17 +4,25 @@ export const INCREASE_LIKE = 0;
 export const DECREASE_LIKE = 1;
 
 const likerInfoReducer = (state, action) => {
-  const { type } = action;
+  const { type, myInfo } = action;
+
+  let { likerCount } = state;
+  let { username } = state;
+
   switch (type) {
     case INCREASE_LIKE:
+      likerCount += 1;
+      if (likerCount === 1) username = myInfo.username;
       return {
         ...state,
-        likerCount: state.likerCount + 1,
+        likerCount,
+        username,
       };
     case DECREASE_LIKE:
+      likerCount -= 1;
       return {
         ...state,
-        likerCount: state.likerCount - 1,
+        likerCount,
       };
     default:
       return state;

--- a/web/src/containers/HomePage/Post/PostMiddle/index.js
+++ b/web/src/containers/HomePage/Post/PostMiddle/index.js
@@ -43,12 +43,7 @@ const PostMiddle = ({ myInfo, post }) => {
           />
           <IconGroup>
             <IconWrapper>
-              <LikeIcon
-                userId={myInfo.id}
-                postId={postId}
-                ratio={5}
-                ref={likeIcon}
-              />
+              <LikeIcon myInfo={myInfo} ratio={5} ref={likeIcon} />
             </IconWrapper>
             <IconWrapper>
               <CommentIcon postURL={postURL} />


### PR DESCRIPTION
- 자신이 올린 게시물에 좋아요가 하나도 없는 상황에서 자신이 좋아요를 눌렀을 때, 좋아요 문구에 프로필 사진이 보이는 버그가 있어서 이를 수정하여 프로필 사진이 뜨지 않도록 함.

close #273 