### PR TITLE
해쉬태그 페이지 리팩토링 및 AnnouncementMessage 구현

### DIFF
--- a/api-server/api/graphql/queries/hashTagPageQuery.js
+++ b/api-server/api/graphql/queries/hashTagPageQuery.js
@@ -1,7 +1,7 @@
 const { GraphQLString } = require('graphql');
 
 const { HashTagPageType } = require('../types');
-const { HashTag, HashTagsOfPost } = require('../../../db');
+const { getHashTagPageData } = require('../../services/HashTagPageService');
 
 const hashTagPageQuery = {
   type: HashTagPageType,
@@ -9,22 +9,8 @@ const hashTagPageQuery = {
     hashTagName: { type: GraphQLString },
   },
   resolve: async (_, args) => {
-    const name = args.hashTagName;
     try {
-      const hashTagId = await HashTag.findOne({
-        attributes: ['id'],
-        where: { name },
-      });
-      let data = { isExistingHashTag: !!hashTagId, postIds: [] };
-      if (hashTagId) {
-        const postIds = await HashTagsOfPost.findAll({
-          attributes: ['PostId'],
-          where: {
-            HashTagId: hashTagId.id,
-          },
-        });
-        data = { ...data, postIds };
-      }
+      const data = await getHashTagPageData(args);
       return data;
     } catch (e) {
       console.log(e.message);

--- a/api-server/api/services/HashTagPageService.js
+++ b/api-server/api/services/HashTagPageService.js
@@ -1,0 +1,32 @@
+const { HashTag, HashTagsOfPost } = require('../../db');
+
+const getHashTagId = async name => {
+  const hashTagId = await HashTag.findOne({
+    attributes: ['id'],
+    where: { name },
+  });
+  return hashTagId;
+};
+
+const getPostIds = async hashTagId => {
+  const postIds = await HashTagsOfPost.findAll({
+    attributes: ['PostId'],
+    where: {
+      HashTagId: hashTagId.id,
+    },
+  });
+  return postIds;
+};
+
+const getHashTagPageData = async args => {
+  const name = args.hashTagName;
+  const hashTagId = await getHashTagId(name);
+  let data = { isExistingHashTag: !!hashTagId, postIds: [] };
+  if (hashTagId) {
+    const postIds = await getPostIds(hashTagId);
+    data = { ...data, postIds };
+  }
+  return data;
+};
+
+module.exports = { getHashTagPageData };

--- a/web/src/components/AnnouncementMessage/AnnouncementMessageWrapper.js
+++ b/web/src/components/AnnouncementMessage/AnnouncementMessageWrapper.js
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+const AnnouncementMessageWrapper = styled.section`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  h2 {
+    font-weight: bold;
+    font-size: 1.5rem;
+  }
+`;
+
+export default AnnouncementMessageWrapper;

--- a/web/src/components/AnnouncementMessage/index.js
+++ b/web/src/components/AnnouncementMessage/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import AnnouncementMessageWrapper from './AnnouncementMessageWrapper';
+
+const AnnouncementMessage = ({ children }) => {
+  return (
+    <AnnouncementMessageWrapper>
+      <h2>{children}</h2>
+    </AnnouncementMessageWrapper>
+  );
+};
+
+export default AnnouncementMessage;

--- a/web/src/containers/HashTagPage/index.js
+++ b/web/src/containers/HashTagPage/index.js
@@ -10,9 +10,12 @@ import {
 } from './styles';
 import ProfileIcon from '../../components/ProfileIcon';
 import PostCardList from '../../components/PostCardList';
+import AnnouncementMessage from '../../components/AnnouncementMessage';
+import Loading from '../../components/Loading';
 
 const HashTagPage = ({ match }) => {
   const { hashTag } = match.params;
+  const loadingSize = 120;
 
   const hashtagPageQuery = gql`
     query HashTagPage($hashTagName: String!) {
@@ -34,13 +37,20 @@ const HashTagPage = ({ match }) => {
     refetch();
   }, [hashTag, refetch]);
 
-  if (loading) return <div>로딩중..</div>;
-  if (error) return <div>에러가 발생했습니다.</div>;
+  if (loading) return <Loading size={loadingSize} />;
+  if (error)
+    return <AnnouncementMessage>에러가 발생했습니다.</AnnouncementMessage>;
   if (!data.hashTagPage.isExistingHashTag)
-    return <div>존재하지않는 해쉬태그입니다.</div>;
+    return (
+      <AnnouncementMessage>존재하지않는 해쉬태그입니다.</AnnouncementMessage>
+    );
   const isPostCardExisting = !!data.hashTagPage.postCard[0];
   if (!isPostCardExisting)
-    return <div>#{hashTag}관련 게시물이 존재하지 않습니다.</div>;
+    return (
+      <AnnouncementMessage>
+        #{hashTag}관련 게시물이 존재하지 않습니다.
+      </AnnouncementMessage>
+    );
   return (
     <HashTagPageWrapper>
       <HashTagInfoWrapper>

--- a/web/src/containers/HashTagPage/index.js
+++ b/web/src/containers/HashTagPage/index.js
@@ -32,12 +32,15 @@ const HashTagPage = ({ match }) => {
 
   useEffect(() => {
     refetch();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hashTag]);
+  }, [hashTag, refetch]);
+
   if (loading) return <div>로딩중..</div>;
   if (error) return <div>에러가 발생했습니다.</div>;
   if (!data.hashTagPage.isExistingHashTag)
     return <div>존재하지않는 해쉬태그입니다.</div>;
+  const isPostCardExisting = !!data.hashTagPage.postCard[0];
+  if (!isPostCardExisting)
+    return <div>#{hashTag}관련 게시물이 존재하지 않습니다.</div>;
   return (
     <HashTagPageWrapper>
       <HashTagInfoWrapper>


### PR DESCRIPTION
- 해쉬태그 페이지 요청에 대한 api-server의 처리 로직을 파일로 분리하여 정리함.
- 해쉬태그가 게시물을 하나도 가지고 있지 않는 경우에 대한 예외처리.
- 공지문구에 css를 적용해주는 AnnouncementMessage 구현
- 로딩시 스피너가 등장하도록 함.

Close #296