### PR TITLE
[Refact] UserPage, HashTagPage의 불필요한 useEffect 제거

### DIFF
--- a/web/src/containers/HashTagPage/index.js
+++ b/web/src/containers/HashTagPage/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { gql } from 'apollo-boost';
 import { useQuery } from '@apollo/react-hooks';
 
@@ -29,13 +29,9 @@ const HashTagPage = ({ match }) => {
     }
   `;
 
-  const { loading, error, data, refetch } = useQuery(hashtagPageQuery, {
+  const { loading, error, data } = useQuery(hashtagPageQuery, {
     variables: { hashTagName: hashTag },
   });
-
-  useEffect(() => {
-    refetch();
-  }, [hashTag, refetch]);
 
   if (loading) return <Loading size={loadingSize} />;
   if (error)

--- a/web/src/containers/UserPage/index.js
+++ b/web/src/containers/UserPage/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { gql } from 'apollo-boost';
 import { useQuery } from '@apollo/react-hooks';
 
@@ -31,13 +31,10 @@ const UserPage = ({ match, myInfo }) => {
     }
   `;
 
-  const { loading, error, data, refetch } = useQuery(userPageQuery, {
+  const { loading, error, data } = useQuery(userPageQuery, {
     variables: { writer: username, myId: id },
   });
-  useEffect(() => {
-    refetch();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [username]);
+
   if (loading) return <div>로딩중..</div>;
   if (error) return <div>에러가 발생했습니다</div>;
   if (!data.userPage.isExistingUser) return <div>존재하지않는 유저입니다.</div>;


### PR DESCRIPTION
이전 커스텀 훅 useFetch를 사용하면서 url변경에 따라 새로운 게시물을
갱신하기위해 useEffect를 활용했던 부분이 useQuery를 사용하게됨에
따라 불필요하여 삭제함.