### PR TITLE
[Fix] 서버에서 검색 안되는 버그 수정

### DIFF
--- a/api-server/api/graphql/queries/SearchQuery.js
+++ b/api-server/api/graphql/queries/SearchQuery.js
@@ -12,7 +12,7 @@ const searchQuery = {
   resolve: (search, args) => {
     const query = `
     ((SELECT id, username, name, profileImage FROM Users WHERE username like :search_value or name like :search_value limit 10)
-    union all (SELECT id, null, name as name, null FROM Hashtags WHERE name like :search_value limit 10)) ORDER BY CASE 
+    union all (SELECT id, null, name as name, null FROM HashTags WHERE name like :search_value limit 10)) ORDER BY CASE 
     WHEN name LIKE :first THEN 1 
     WHEN name LIKE :second THEN 2 
     WHEN name LIKE :last THEN 4 


### PR DESCRIPTION
로컬에서는 테이블명에 대소문자 구분이 없지만 배포서버에는 있어
테이블명 오류로 검색이 되지않아 테이블명 수정.

closed #356 and closed #342