### PR TITLE
[Review] 공통되는 데이터 캐싱

### DIFF
--- a/web/src/containers/HomePage/Post/CommentInput/CommentInputWrapper.js
+++ b/web/src/containers/HomePage/Post/CommentInput/CommentInputWrapper.js
@@ -1,0 +1,21 @@
+import styled, { css } from 'styled-components';
+
+const Wrapper = styled.div`
+  position: relative;
+  flex: 0 0 56px;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  input {
+    border: none;
+    margin-left: 16px;
+  }
+  ${({ theme }) => {
+    const borderColor = theme.palette.border;
+    return css`
+      border-top: 1px solid ${borderColor};
+    `;
+  }}
+`;
+
+export default Wrapper;

--- a/web/src/containers/HomePage/Post/CommentInput/StyledButton.js
+++ b/web/src/containers/HomePage/Post/CommentInput/StyledButton.js
@@ -1,0 +1,19 @@
+import styled, { css } from 'styled-components';
+
+const StyledButton = styled.button`
+  ${props => {
+    const { disabled } = props;
+    const { blue } = props.theme.palette;
+    return css`
+      font-weight: 600;
+      color: ${blue};
+      background: 0 0;
+      border: 0;
+      padding: 0;
+      margin-right: 16px;
+      opacity: ${disabled ? 0.5 : 1};
+    `;
+  }}
+`;
+
+export default StyledButton;

--- a/web/src/containers/HomePage/Post/CommentInput/StyledForm.js
+++ b/web/src/containers/HomePage/Post/CommentInput/StyledForm.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+const StyledForm = styled.form`
+  width: 100%;
+  display: flex;
+`;
+
+export default StyledForm;

--- a/web/src/containers/HomePage/Post/CommentInput/StyledInput.js
+++ b/web/src/containers/HomePage/Post/CommentInput/StyledInput.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const StyledInput = styled.input`
+  outline: none;
+  flex: 1 0 auto;
+`;
+export default StyledInput;

--- a/web/src/containers/HomePage/Post/CommentInput/index.js
+++ b/web/src/containers/HomePage/Post/CommentInput/index.js
@@ -1,0 +1,75 @@
+import React, { useState, useContext } from 'react';
+import { useMutation } from '@apollo/react-hooks';
+import { FOLLOWING_POST_LIST, CREATE_COMMENT } from '../../../../queries';
+import Loading from '../../../../components/Loading';
+import UserContext from '../../../App/UserContext';
+
+import {
+  StyledForm,
+  StyledButton,
+  StyledInput,
+  CommentInputWrapper,
+} from './styles';
+
+function CommentInput({ PostId }) {
+  const { myInfo } = useContext(UserContext);
+  const [addComment, { loading }] = useMutation(CREATE_COMMENT, {
+    update(cache, { data: { createComment } }) {
+      const { followingPostList } = cache.readQuery({
+        query: FOLLOWING_POST_LIST,
+        variables: {
+          myId: myInfo.id,
+          offset: 0,
+          limit: 5,
+        },
+      });
+      const changedFollowingPostList = [...followingPostList];
+
+      changedFollowingPostList
+        .find(post => +post.id === PostId)
+        .commentList.push(createComment);
+      cache.writeQuery({
+        query: FOLLOWING_POST_LIST,
+        variables: {
+          myId: myInfo.id,
+          offset: 0,
+          limit: 5,
+        },
+        data: { followingPostList: changedFollowingPostList },
+      });
+    },
+  });
+
+  const [text, setText] = useState('');
+
+  const isEmpty = text === '';
+
+  const onChange = e => {
+    setText(e.target.value);
+  };
+
+  const submitHandler = e => {
+    e.preventDefault();
+    if (loading) return;
+    addComment({ variables: { content: text, PostId, UserId: myInfo.id } });
+    setText('');
+  };
+
+  return (
+    <CommentInputWrapper>
+      {loading && <Loading size={20} />}
+      <StyledForm onSubmit={submitHandler}>
+        <StyledInput
+          placeholder="댓글달기..."
+          onChange={onChange}
+          value={text}
+        />
+        <StyledButton type="submit" disabled={isEmpty}>
+          게시
+        </StyledButton>
+      </StyledForm>
+    </CommentInputWrapper>
+  );
+}
+
+export default CommentInput;

--- a/web/src/containers/HomePage/Post/CommentInput/reducer.js
+++ b/web/src/containers/HomePage/Post/CommentInput/reducer.js
@@ -1,0 +1,26 @@
+function reducer(state, action) {
+  switch (action.type) {
+    case 'LOADING':
+      return {
+        loading: true,
+        data: null,
+        error: null,
+      };
+    case 'SUCCESS':
+      return {
+        loading: false,
+        data: action.data,
+        error: null,
+      };
+    case 'ERROR':
+      return {
+        loading: false,
+        data: null,
+        error: action.error,
+      };
+    default:
+      throw new Error(`Unhandled action type: ${action.type}`);
+  }
+}
+
+export default reducer;

--- a/web/src/containers/HomePage/Post/CommentInput/styles.js
+++ b/web/src/containers/HomePage/Post/CommentInput/styles.js
@@ -1,0 +1,6 @@
+import CommentInputWrapper from './CommentInputWrapper';
+import StyledButton from './StyledButton';
+import StyledInput from './StyledInput';
+import StyledForm from './StyledForm';
+
+export { CommentInputWrapper, StyledButton, StyledInput, StyledForm };

--- a/web/src/containers/HomePage/Post/PostBottom/AllCommentShowText.js
+++ b/web/src/containers/HomePage/Post/PostBottom/AllCommentShowText.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import StyledLink from '../../../../components/StyledLink';
+
+const AllCommentShowTextSpan = styled.span`
+  margin-left: 15px;
+  padding: 0px;
+
+  line-height: 1;
+  font-size: 0.8rem;
+  color: ${({ theme }) => theme.palette.gray_font};
+`;
+
+const AllCommentShowText = ({ postURL, commentCount }) => {
+  const isVisible = commentCount >= 3;
+  return (
+    <>
+      {isVisible && (
+        <StyledLink to={`/p/${postURL}`} style={{ marginBottom: '8px' }}>
+          <AllCommentShowTextSpan>
+            댓글 {commentCount}개 모두 보기
+          </AllCommentShowTextSpan>
+        </StyledLink>
+      )}
+    </>
+  );
+};
+
+export default AllCommentShowText;

--- a/web/src/containers/HomePage/Post/PostBottom/index.js
+++ b/web/src/containers/HomePage/Post/PostBottom/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { AllCommentShowText } from './styles';
+import { Comment, MainText } from '../PostText';
+import TimePassed from '../../../../components/TimePassed';
+
+const PostBottom = ({ myInfo, post }) => {
+  const {
+    writer,
+    commentCount,
+    commentList,
+    postURL,
+    content: mainText,
+    updatedAt,
+  } = post;
+
+  return (
+    <>
+      <MainText writer={writer} mainText={mainText} />
+      <AllCommentShowText postURL={postURL} commentCount={commentCount} />
+      {commentList.map(c => (
+        <Comment key={c.id} myInfo={myInfo} comment={c} />
+      ))}
+      <TimePassed updatedAt={updatedAt} />
+    </>
+  );
+};
+
+export default PostBottom;

--- a/web/src/containers/HomePage/Post/PostBottom/styles.js
+++ b/web/src/containers/HomePage/Post/PostBottom/styles.js
@@ -1,0 +1,3 @@
+import AllCommentShowText from './AllCommentShowText';
+
+export { AllCommentShowText };

--- a/web/src/containers/HomePage/Post/PostMiddle/CommentIcon.js
+++ b/web/src/containers/HomePage/Post/PostMiddle/CommentIcon.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import Icon from '../../../../components/Icon';
+import StyledLink from '../../../../components/StyledLink';
+
+const LinkStyle = {
+  height: '25px',
+};
+
+const CommentIcon = ({ postURL }) => {
+  return (
+    <StyledLink to={`/p/${postURL}`} style={LinkStyle}>
+      <Icon name="comment" />
+    </StyledLink>
+  );
+};
+
+CommentIcon.defaultProps = {
+  ratio: 5,
+};
+
+export default CommentIcon;

--- a/web/src/containers/HomePage/Post/PostMiddle/IconGroup.js
+++ b/web/src/containers/HomePage/Post/PostMiddle/IconGroup.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const IconGroup = styled.div`
+  display: flex;
+  align-items: center;
+  min-height: 40px;
+  margin: 4px 8px 0px 8px;
+`;
+
+export default IconGroup;

--- a/web/src/containers/HomePage/Post/PostMiddle/IconWrapper.js
+++ b/web/src/containers/HomePage/Post/PostMiddle/IconWrapper.js
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+const IconWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  flex: 0 0 40px;
+  height: 40px;
+`;
+
+export default IconWrapper;

--- a/web/src/containers/HomePage/Post/PostMiddle/PostImage.js
+++ b/web/src/containers/HomePage/Post/PostMiddle/PostImage.js
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+const POST_IMAGE_LENGTH = 615;
+
+const PostImage = styled.div`
+  background-image: url(${({ imageURL }) => imageURL});
+  background-size: cover;
+  background-repeat: no-repeat;
+
+  border-bottom: 1px solid ${({ theme }) => theme.palette.border};
+
+  width: ${POST_IMAGE_LENGTH}px;
+  height: ${POST_IMAGE_LENGTH}px;
+
+  margin-bottom: 4px;
+
+  cursor: pointer;
+`;
+
+export default PostImage;

--- a/web/src/containers/HomePage/Post/PostMiddle/PostMiddleWrapper.js
+++ b/web/src/containers/HomePage/Post/PostMiddle/PostMiddleWrapper.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const PostMiddleWrapperDiv = styled.div``;
+
+const PostMiddleWrapper = props => {
+  const { children, ...rest } = props;
+  return <PostMiddleWrapperDiv {...rest}>{children}</PostMiddleWrapperDiv>;
+};
+
+export default PostMiddleWrapper;

--- a/web/src/containers/HomePage/Post/PostMiddle/index.js
+++ b/web/src/containers/HomePage/Post/PostMiddle/index.js
@@ -1,0 +1,73 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import _ from 'underscore';
+import { useMutation } from '@apollo/react-hooks';
+
+import { CREATE_POST_LIKE, DELETE_POST_LIKE } from '../../../../queries';
+import LikeIcon from '../../../../components/LikeIcon';
+import LikeInfo from '../../../../components/LikeInfo';
+import {
+  CommentIcon,
+  IconGroup,
+  IconWrapper,
+  PostImage,
+  PostMiddleWrapper,
+} from './styles';
+
+const PostMiddle = ({ myInfo, post }) => {
+  const [createPostLike] = useMutation(CREATE_POST_LIKE);
+  const [deletePostLike] = useMutation(DELETE_POST_LIKE);
+
+  const { id: postId, isLike, imageURL, postURL, likerInfo, UserId } = post;
+  const [isLikeClicked, setLikeState] = useState(isLike);
+  const likeBtnClickHandler = () => {
+    const currentClickStatus = !isLikeClicked;
+    if (currentClickStatus)
+      createPostLike({
+        variables: { PostId: postId, WriterId: +UserId, UserId: myInfo.id },
+      });
+    else deletePostLike({ variables: { PostId: postId, UserId: myInfo.id } });
+  };
+
+  const lazyFetch = useCallback(_.debounce(likeBtnClickHandler, 1000), []);
+
+  const toggleLikeState = () => {
+    setLikeState(!isLikeClicked);
+    if (isLikeClicked !== isLike) return;
+    lazyFetch();
+  };
+
+  const postImage = useRef(null);
+  const wrapperProps = { postImage, userId: myInfo.id, postId };
+
+  useEffect(() => {
+    setLikeState(isLike);
+  }, [isLike]);
+
+  return (
+    <PostMiddleWrapper {...wrapperProps}>
+      <PostImage
+        myInfo={myInfo}
+        imageURL={imageURL}
+        ref={postImage}
+        onDoubleClick={toggleLikeState}
+      />
+      <IconGroup>
+        <IconWrapper>
+          <LikeIcon isFull={isLikeClicked} onClick={toggleLikeState} />
+        </IconWrapper>
+        <IconWrapper>
+          <CommentIcon postURL={postURL} />
+        </IconWrapper>
+      </IconGroup>
+      <LikeInfo
+        myInfo={myInfo}
+        postId={postId}
+        diff={isLikeClicked - isLike}
+        likerInfo={likerInfo}
+      />
+    </PostMiddleWrapper>
+  );
+};
+
+export default PostMiddle;

--- a/web/src/containers/HomePage/Post/PostMiddle/styles.js
+++ b/web/src/containers/HomePage/Post/PostMiddle/styles.js
@@ -1,0 +1,7 @@
+import CommentIcon from './CommentIcon';
+import IconGroup from './IconGroup';
+import IconWrapper from './IconWrapper';
+import PostImage from './PostImage';
+import PostMiddleWrapper from './PostMiddleWrapper';
+
+export { CommentIcon, IconGroup, IconWrapper, PostImage, PostMiddleWrapper };

--- a/web/src/containers/HomePage/Post/PostText/Comment/CommentWrapper.js
+++ b/web/src/containers/HomePage/Post/PostText/Comment/CommentWrapper.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { TextWrapper } from '../styles';
+
+const CommentWrapper = ({ children }) => {
+  return <TextWrapper>{children}</TextWrapper>;
+};
+
+export default CommentWrapper;

--- a/web/src/containers/HomePage/Post/PostText/Comment/index.js
+++ b/web/src/containers/HomePage/Post/PostText/Comment/index.js
@@ -1,0 +1,32 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React, { useRef } from 'react';
+
+import {
+  Content as CommentContent,
+  TextMoreButton as CommentMoreButton,
+  Writer as Commenter,
+} from '../styles';
+import CommentWrapper from './CommentWrapper';
+import { useText as useComment } from '../hooks';
+
+const Comment = ({ myInfo, comment }) => {
+  const [isFold, commentRef, onUnfoldComment] = useComment();
+  const likeIcon = useRef(null);
+
+  const { id: commentId, writer: commenter, content } = comment;
+  const wrapperProps = { userId: myInfo.id, commentId, likeIcon };
+
+  return (
+    <CommentWrapper {...wrapperProps}>
+      <Commenter to={`/${commenter.username}`}>{commenter.username}</Commenter>
+      <CommentContent isFold={isFold} ref={commentRef}>
+        {content}
+      </CommentContent>
+      <CommentMoreButton onClick={onUnfoldComment} isFold={isFold}>
+        더 보기
+      </CommentMoreButton>
+    </CommentWrapper>
+  );
+};
+
+export default Comment;

--- a/web/src/containers/HomePage/Post/PostText/Content.js
+++ b/web/src/containers/HomePage/Post/PostText/Content.js
@@ -1,0 +1,18 @@
+import styled, { css } from 'styled-components';
+
+const Content = styled.span`
+  padding-right: 2px;
+  line-height: 1;
+
+  ${({ isFold }) => {
+    if (!isFold) return null;
+
+    return css`
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+    `;
+  }}
+`;
+
+export default Content;

--- a/web/src/containers/HomePage/Post/PostText/MainText/index.js
+++ b/web/src/containers/HomePage/Post/PostText/MainText/index.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import {
+  Content as MainTextContent,
+  TextWrapper as MainTextWrapper,
+  TextMoreButton as MaintextMoreButton,
+  Writer,
+} from '../styles';
+import { useText as useMainText } from '../hooks';
+import { parseMainText, makeMainText } from './lib';
+
+const MainText = ({ writer, mainText }) => {
+  const { username } = writer;
+  const [isFold, mainTextRef, onUnfoldMainText] = useMainText();
+  const parseResult = parseMainText(mainText);
+
+  return (
+    <MainTextWrapper style={{ marginBottom: '4px' }}>
+      <Writer to={`/${username}`}>{username}</Writer>
+      <MainTextContent isFold={isFold} ref={mainTextRef}>
+        {parseResult.map(content => makeMainText(content))}
+      </MainTextContent>
+      {isFold && (
+        <MaintextMoreButton onClick={onUnfoldMainText}>
+          더보기
+        </MaintextMoreButton>
+      )}
+    </MainTextWrapper>
+  );
+};
+
+export default MainText;

--- a/web/src/containers/HomePage/Post/PostText/MainText/lib/index.js
+++ b/web/src/containers/HomePage/Post/PostText/MainText/lib/index.js
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import StyledLink from '../../../../../../components/StyledLink';
+
+export function parseMainText(content) {
+  let isTag = false;
+  const result = Array.from(content).reduce(
+    (acc, char) => {
+      if (isTag && char === ' ') {
+        isTag = false;
+        return [...acc, char];
+      }
+
+      if (char !== '@' && char !== '#') {
+        const { length } = acc;
+        const last = acc[length - 1].concat(char);
+        return [...acc.slice(0, length - 1), last];
+      }
+
+      isTag = true;
+      return [...acc, char];
+    },
+    [''],
+  );
+
+  return result;
+}
+
+export function makeMainText(content) {
+  if (content.startsWith('@')) {
+    const username = content.substring(1);
+    return (
+      <StyledLink
+        style={{ color: '#0d4296' }}
+        key={username}
+        to={`/${username}`}
+      >
+        {content}
+      </StyledLink>
+    );
+  }
+
+  if (content.startsWith('#')) {
+    const hashtag = content.substring(1);
+    return (
+      <StyledLink
+        style={{ color: '#0d4296' }}
+        key={hashtag}
+        to={`/h/${hashtag}`}
+      >
+        {content}
+      </StyledLink>
+    );
+  }
+
+  return content;
+}

--- a/web/src/containers/HomePage/Post/PostText/TextMoreButton.js
+++ b/web/src/containers/HomePage/Post/PostText/TextMoreButton.js
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+const TextMoreButton = styled.button`
+  background-color: transparent;
+  border: none;
+  outline: none;
+  color: ${({ theme }) => theme.palette.gray_font};
+  font-size: 0.8rem;
+  line-height: 1;
+
+  flex: 1 0 auto;
+
+  cursor: pointer;
+
+  display: ${({ isFold }) => (isFold ? '' : 'none')};
+`;
+
+export default TextMoreButton;

--- a/web/src/containers/HomePage/Post/PostText/TextWrapper.js
+++ b/web/src/containers/HomePage/Post/PostText/TextWrapper.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+const TextWrapper = styled.div`
+  display: flex;
+  align-items: center;
+
+  font-size: 0.95rem;
+  margin: 0px 15px;
+`;
+
+export default TextWrapper;

--- a/web/src/containers/HomePage/Post/PostText/Writer.js
+++ b/web/src/containers/HomePage/Post/PostText/Writer.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+import StyledLink from '../../../../components/StyledLink';
+
+const Writer = styled(StyledLink)`
+  margin-right: 8px;
+  font-weight: 600;
+
+  align-self: flex-start;
+`;
+
+export default Writer;

--- a/web/src/containers/HomePage/Post/PostText/hooks/index.js
+++ b/web/src/containers/HomePage/Post/PostText/hooks/index.js
@@ -1,0 +1,4 @@
+import useText from './useText';
+
+// eslint-disable-next-line import/prefer-default-export
+export { useText };

--- a/web/src/containers/HomePage/Post/PostText/hooks/useText.js
+++ b/web/src/containers/HomePage/Post/PostText/hooks/useText.js
@@ -1,0 +1,19 @@
+import { useState, useRef, useEffect } from 'react';
+
+const useText = () => {
+  const [isFold, setIsFold] = useState(true);
+  const onUnfoldText = () => {
+    setIsFold(!isFold);
+  };
+
+  const textRef = useRef(null);
+  useEffect(() => {
+    const { offsetWidth, scrollWidth } = textRef.current;
+    const isOverflow = offsetWidth < scrollWidth;
+    setIsFold(isOverflow);
+  }, []);
+
+  return [isFold, textRef, onUnfoldText];
+};
+
+export default useText;

--- a/web/src/containers/HomePage/Post/PostText/index.js
+++ b/web/src/containers/HomePage/Post/PostText/index.js
@@ -1,0 +1,4 @@
+import Comment from './Comment';
+import MainText from './MainText';
+
+export { Comment, MainText };

--- a/web/src/containers/HomePage/Post/PostText/styles.js
+++ b/web/src/containers/HomePage/Post/PostText/styles.js
@@ -1,0 +1,6 @@
+import Content from './Content';
+import TextMoreButton from './TextMoreButton';
+import TextWrapper from './TextWrapper';
+import Writer from './Writer';
+
+export { Content, TextMoreButton, TextWrapper, Writer };

--- a/web/src/containers/HomePage/Post/PostWrapper.js
+++ b/web/src/containers/HomePage/Post/PostWrapper.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+const POST_WIDTH = 615;
+
+const PostWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  width: ${POST_WIDTH}px;
+
+  border-color: ${({ theme }) => theme.palette.border};
+  border-width: 1px;
+  border-style: solid;
+
+  background-color: ${({ theme }) => theme.palette.white};
+
+  & + & {
+    margin-top: 60px;
+  }
+`;
+
+export default PostWrapper;

--- a/web/src/containers/HomePage/Post/index.js
+++ b/web/src/containers/HomePage/Post/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import PostWrapper from './PostWrapper';
+import PostTop from '../../../components/PostTop';
+import PostMiddle from './PostMiddle';
+import PostBottom from './PostBottom';
+import CommentInput from './CommentInput';
+
+const Post = React.forwardRef(({ myInfo, post }, ref) => {
+  const { writer, postURL } = post;
+
+  return (
+    <PostWrapper ref={ref}>
+      <PostTop myInfo={myInfo} writer={writer} postURL={postURL} />
+      <PostMiddle myInfo={myInfo} post={post} />
+      <PostBottom myInfo={myInfo} post={post} />
+      <CommentInput PostId={+post.id} />
+    </PostWrapper>
+  );
+});
+
+export default Post;

--- a/web/src/containers/HomePage/PostListWrapper.js
+++ b/web/src/containers/HomePage/PostListWrapper.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const PostListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 60px;
+`;
+
+export default PostListWrapper;

--- a/web/src/containers/HomePage/SpinnerWrapper.js
+++ b/web/src/containers/HomePage/SpinnerWrapper.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const SpinnerWrapper = styled.div`
+  padding: 50px 0px;
+`;
+
+export default SpinnerWrapper;

--- a/web/src/containers/HomePage/index.js
+++ b/web/src/containers/HomePage/index.js
@@ -1,0 +1,89 @@
+import React, { useRef, useEffect, useState, useContext } from 'react';
+import { useQuery } from '@apollo/react-hooks';
+import 'intersection-observer';
+
+import Post from './Post';
+import { PostListWrapper, SpinnerWrapper } from './styles';
+import { FOLLOWING_POST_LIST } from '../../queries';
+import Spinner from '../../components/Spinner';
+import UserContext from '../App/UserContext';
+
+const LIMIT = 5;
+function HomePage() {
+  const { myInfo } = useContext(UserContext);
+  const [noMorePost, setNoMorePost] = useState(false);
+  const lastChild = useRef();
+  const { data, loading, error, fetchMore } = useQuery(FOLLOWING_POST_LIST, {
+    variables: {
+      myId: myInfo.id,
+      limit: LIMIT,
+    },
+    fetchPolicy: 'cache-first',
+    notifyOnNetworkStatusChange: true,
+  });
+
+  const options = {
+    root: null,
+    threshold: 0,
+  };
+  const getMorePosts = (entries, observer) => {
+    if (loading) return;
+    if (data && !data.followingPostList.length) return;
+    const entry = entries[0];
+    if (!entry.isIntersecting) return;
+    observer.disconnect();
+    const list = data.followingPostList;
+    const cursor = list.length ? [...list].pop().updatedAt : null;
+    fetchMore({
+      variables: {
+        cursor,
+      },
+      updateQuery: (prev, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return prev;
+        if (!fetchMoreResult.followingPostList.length) setNoMorePost(true);
+        return {
+          ...prev,
+          followingPostList: [
+            ...prev.followingPostList,
+            ...fetchMoreResult.followingPostList,
+          ],
+        };
+      },
+    });
+  };
+
+  const { followingPostList } = data || { followingPostList: [] };
+
+  const postList = followingPostList.map((post, index) => (
+    <Post key={post.id} post={post} myInfo={myInfo} />
+  ));
+
+  useEffect(() => {
+    if (!lastChild.current) return;
+    if (noMorePost) return;
+    const observer = new IntersectionObserver(getMorePosts, options);
+    observer.observe(lastChild.current);
+
+    if (data && !followingPostList.length) setNoMorePost(true);
+
+    // eslint-disable-next-line consistent-return
+    return () => observer.disconnect();
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [followingPostList]);
+
+  if (error) return <div>에러가 발생했습니다</div>;
+
+  return (
+    <PostListWrapper>
+      {postList}
+      {!noMorePost && (
+        <SpinnerWrapper ref={lastChild}>
+          <Spinner size={50} />
+        </SpinnerWrapper>
+      )}
+    </PostListWrapper>
+  );
+}
+
+export default HomePage;

--- a/web/src/containers/HomePage/styles.js
+++ b/web/src/containers/HomePage/styles.js
@@ -1,0 +1,4 @@
+import PostListWrapper from './PostListWrapper';
+import SpinnerWrapper from './SpinnerWrapper';
+
+export { PostListWrapper, SpinnerWrapper };

--- a/web/src/containers/PostDetailPage/PostDetailPageWrapper.js
+++ b/web/src/containers/PostDetailPage/PostDetailPageWrapper.js
@@ -1,0 +1,23 @@
+import styled, { css } from 'styled-components';
+
+const borderStyle = css`
+  ${({ theme }) => css`
+    border: solid 1px ${theme.palette.border};
+  `}}
+`;
+const backgroundColorStyle = css`
+  ${({ theme }) => css`
+    background-color: ${theme.palette.white};
+  `}}
+`;
+const PostDetailPageWrapper = styled.div`
+  width: 950px;
+  margin: -10px auto 16px auto;
+  display: flex;
+  align-items: stretch;
+  box-sizing: border-box;
+  ${borderStyle};
+  ${backgroundColorStyle}
+`;
+
+export default PostDetailPageWrapper;

--- a/web/src/containers/PostDetailPage/PostSideBox/CommentInput/CommentInputWrapper.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/CommentInput/CommentInputWrapper.js
@@ -1,0 +1,21 @@
+import styled, { css } from 'styled-components';
+
+const Wrapper = styled.div`
+  position: relative;
+  flex: 0 0 56px;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  input {
+    border: none;
+    margin-left: 16px;
+  }
+  ${({ theme }) => {
+    const borderColor = theme.palette.border;
+    return css`
+      border-top: 1px solid ${borderColor};
+    `;
+  }}
+`;
+
+export default Wrapper;

--- a/web/src/containers/PostDetailPage/PostSideBox/CommentInput/StyledButton.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/CommentInput/StyledButton.js
@@ -1,0 +1,19 @@
+import styled, { css } from 'styled-components';
+
+const StyledButton = styled.button`
+  ${props => {
+    const { disabled } = props;
+    const { blue } = props.theme.palette;
+    return css`
+      font-weight: 600;
+      color: ${blue};
+      background: 0 0;
+      border: 0;
+      padding: 0;
+      margin-right: 16px;
+      opacity: ${disabled ? 0.5 : 1};
+    `;
+  }}
+`;
+
+export default StyledButton;

--- a/web/src/containers/PostDetailPage/PostSideBox/CommentInput/StyledForm.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/CommentInput/StyledForm.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+const StyledForm = styled.form`
+  width: 100%;
+  display: flex;
+`;
+
+export default StyledForm;

--- a/web/src/containers/PostDetailPage/PostSideBox/CommentInput/StyledInput.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/CommentInput/StyledInput.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const StyledInput = styled.input`
+  outline: none;
+  flex: 1 0 auto;
+`;
+export default StyledInput;

--- a/web/src/containers/PostDetailPage/PostSideBox/CommentInput/index.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/CommentInput/index.js
@@ -1,0 +1,70 @@
+import React, { useState, useContext } from 'react';
+import { useMutation } from '@apollo/react-hooks';
+import { CREATE_COMMENT, COMMENT_LIST } from '../../../../queries';
+import Loading from '../../../../components/Loading';
+import UserContext from '../../../App/UserContext';
+
+import {
+  StyledForm,
+  StyledButton,
+  StyledInput,
+  CommentInputWrapper,
+} from './styles';
+
+function CommentInput({ PostId }) {
+  const { myInfo } = useContext(UserContext);
+  const [addComment, { loading }] = useMutation(CREATE_COMMENT, {
+    update(cache, { data: { createComment } }) {
+      const { commentList } = cache.readQuery({
+        query: COMMENT_LIST,
+        variables: {
+          PostId,
+          offset: 0,
+          limit: 5,
+        },
+      });
+      cache.writeQuery({
+        query: COMMENT_LIST,
+        variables: {
+          PostId,
+          offset: 0,
+          limit: 5,
+        },
+        data: { commentList: [createComment].concat(commentList) },
+      });
+    },
+  });
+
+  const [text, setText] = useState('');
+
+  const isEmpty = text === '';
+
+  const onChange = e => {
+    setText(e.target.value);
+  };
+
+  const submitHandler = e => {
+    if (loading) return;
+    e.preventDefault();
+    addComment({ variables: { content: text, PostId, UserId: myInfo.id } });
+    setText('');
+  };
+
+  return (
+    <CommentInputWrapper>
+      {loading && <Loading size={20} />}
+      <StyledForm onSubmit={submitHandler}>
+        <StyledInput
+          placeholder="댓글달기..."
+          onChange={onChange}
+          value={text}
+        />
+        <StyledButton type="submit" disabled={isEmpty}>
+          게시
+        </StyledButton>
+      </StyledForm>
+    </CommentInputWrapper>
+  );
+}
+
+export default CommentInput;

--- a/web/src/containers/PostDetailPage/PostSideBox/CommentInput/reducer.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/CommentInput/reducer.js
@@ -1,0 +1,26 @@
+function reducer(state, action) {
+  switch (action.type) {
+    case 'LOADING':
+      return {
+        loading: true,
+        data: null,
+        error: null,
+      };
+    case 'SUCCESS':
+      return {
+        loading: false,
+        data: action.data,
+        error: null,
+      };
+    case 'ERROR':
+      return {
+        loading: false,
+        data: null,
+        error: action.error,
+      };
+    default:
+      throw new Error(`Unhandled action type: ${action.type}`);
+  }
+}
+
+export default reducer;

--- a/web/src/containers/PostDetailPage/PostSideBox/CommentInput/styles.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/CommentInput/styles.js
@@ -1,0 +1,6 @@
+import CommentInputWrapper from './CommentInputWrapper';
+import StyledButton from './StyledButton';
+import StyledInput from './StyledInput';
+import StyledForm from './StyledForm';
+
+export { CommentInputWrapper, StyledButton, StyledInput, StyledForm };

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/CommentWrapper.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/CommentWrapper.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+const CommentWrapper = styled.li`
+  display: flex;
+  list-style-type: none;
+  width: 100%;
+  padding: 12px 16px 0px 16px;
+  box-sizing: border-box;
+  & + & {
+    margin-top: 16px;
+  }
+  h3 {
+    font-weight: 600;
+    display: inline;
+    margin-right: 5px;
+  }
+  article {
+    display: inline;
+  }
+`;
+
+export default CommentWrapper;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/Content/ContentWrapper.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/Content/ContentWrapper.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+const ContentWrapper = styled.section`
+  font-size: 14px;
+  flex: 1 0 auto;
+  main {
+    margin-bottom: 16px;
+  }
+`;
+
+export default ContentWrapper;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/Content/UpdatedTime.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/Content/UpdatedTime.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const UpdatedTime = styled.time`
+  color: ${({ theme }) => theme.palette.gray_font};
+  font-size: 15px;
+  font-weight: 400;
+  margin-right: 16px;
+`;
+
+export default UpdatedTime;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/Content/index.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/Content/index.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { ContentWrapper } from './styles';
+import StyledLink from '../../../../../../../components/StyledLink';
+import TimePassed from '../../../../../../../components/TimePassed';
+
+function Content({ comment }) {
+  const { writer, content, updatedAt } = comment;
+  return (
+    <ContentWrapper>
+      <main>
+        <h3>
+          <StyledLink
+            to={`/${writer.username}`}
+            style={{ display: 'inline-block' }}
+          >
+            {writer.username}
+          </StyledLink>
+        </h3>
+        <article>{content}</article>
+      </main>
+      <TimePassed updatedAt={updatedAt} />
+    </ContentWrapper>
+  );
+}
+
+export default Content;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/Content/styles.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/Content/styles.js
@@ -1,0 +1,4 @@
+import ContentWrapper from './ContentWrapper';
+import UpdatedTime from './UpdatedTime';
+
+export { ContentWrapper, UpdatedTime };

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/ProfileWrapper.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/ProfileWrapper.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const ProfileWrapper = styled.div`
+  margin-right: 18px;
+`;
+
+export default ProfileWrapper;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/index.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { CommentWrapper, ProfileWrapper } from './styles';
+import ProfileIcon from '../../../../../../components/ProfileIcon';
+import Content from './Content';
+
+const Comment = ({ comment }) => {
+  return (
+    <CommentWrapper>
+      <ProfileWrapper>
+        <ProfileIcon />
+      </ProfileWrapper>
+      <Content comment={comment} />
+    </CommentWrapper>
+  );
+};
+
+export default Comment;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/styles.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/Comment/styles.js
@@ -1,0 +1,4 @@
+import CommentWrapper from './CommentWrapper';
+import ProfileWrapper from './ProfileWrapper';
+
+export { CommentWrapper, ProfileWrapper };

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/CommentListWrapper.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/CommentListWrapper.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+const CommentListWrapper = styled.ul`
+  padding: 0px;
+  overflow: auto;
+`;
+
+export default CommentListWrapper;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/MoreCommentButton.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/MoreCommentButton.js
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+const MoreCommentButton = styled.button`
+  width: 100%;
+  height: 40px;
+  margin: 10px 0;
+
+  background-color: transparent;
+  border: none;
+
+  display: flex;
+  justify-content: space-around;
+
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+export default MoreCommentButton;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/index.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/index.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useQuery } from '@apollo/react-hooks';
+
+import { CommentListWrapper, MoreCommentButton } from './styles';
+import Comment from './Comment';
+import Icon from '../../../../../components/Icon';
+import { COMMENT_LIST } from '../../../queries';
+
+function CommentList({ PostId }) {
+  const { data, error, fetchMore } = useQuery(COMMENT_LIST, {
+    variables: {
+      PostId,
+      offset: 0,
+      limit: 5,
+    },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  let comments = [];
+  if (error) return <div>에러가 발생했습니다</div>;
+  if (data) comments = data.commentList;
+
+  const getMoreComments = () => {
+    fetchMore({
+      variables: {
+        offset: data.commentList.length,
+      },
+      updateQuery: (prev, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return prev;
+        return {
+          ...prev,
+          commentList: [...prev.commentList, ...fetchMoreResult.commentList],
+        };
+      },
+    });
+  };
+
+  return (
+    <CommentListWrapper>
+      {comments.map(comment => (
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        <Comment key={comment.id} comment={comment} />
+      ))}
+      <MoreCommentButton onClick={getMoreComments}>
+        <Icon ratio={6} posX={-385} posY={-498} />
+      </MoreCommentButton>
+    </CommentListWrapper>
+  );
+}
+
+export default CommentList;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/styles.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/CommentList/styles.js
@@ -1,0 +1,4 @@
+import MoreCommentButton from './MoreCommentButton';
+import CommentListWrapper from './CommentListWrapper';
+
+export { MoreCommentButton, CommentListWrapper };

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostContentWrapper.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostContentWrapper.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+const PostContentWrapper = styled.div`
+  flex: 1 1 400px;
+  overflow: auto;
+`;
+
+export default PostContentWrapper;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/Content/ContentWrapper.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/Content/ContentWrapper.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const ContentWrapper = styled.section`
+  font-size: 14px;
+  main {
+    margin-bottom: 16px;
+  }
+`;
+
+export default ContentWrapper;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/Content/StyledTime.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/Content/StyledTime.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const StyledTime = styled.time`
+  color: ${({ theme }) => theme.palette.gray_font};
+  font-size: 15px;
+  font-weight: 400;
+  margin-right: 16px;
+`;
+
+export default StyledTime;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/Content/index.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/Content/index.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { ContentWrapper, StyledTime } from './styles';
+import StyledLink from '../../../../../../components/StyledLink';
+
+function Content({ post }) {
+  const { writer, content } = post;
+  return (
+    <ContentWrapper>
+      <main>
+        <h3>
+          <StyledLink
+            to={`/${writer.username}`}
+            style={{ display: 'inline-block' }}
+          >
+            {writer.username}
+          </StyledLink>
+        </h3>
+        <article>{content}</article>
+      </main>
+      <StyledTime>5h</StyledTime>
+    </ContentWrapper>
+  );
+}
+
+export default Content;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/Content/styles.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/Content/styles.js
@@ -1,0 +1,4 @@
+import ContentWrapper from './ContentWrapper';
+import StyledTime from './StyledTime';
+
+export { ContentWrapper, StyledTime };

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/PostTextWrapper.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/PostTextWrapper.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+const PostTextWrapper = styled.li`
+  display: flex;
+  list-style-type: none;
+  width: 100%;
+  padding: 12px 16px 0px 16px;
+  box-sizing: border-box;
+  & + & {
+    margin-top: 16px;
+  }
+  h3 {
+    font-weight: 600;
+    display: inline;
+    margin-right: 5px;
+  }
+  article {
+    display: inline;
+  }
+`;
+
+export default PostTextWrapper;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/ProfileWrapper.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/ProfileWrapper.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const ProfileWrapper = styled.div`
+  margin-right: 18px;
+`;
+
+export default ProfileWrapper;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/index.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { PostTextWrapper, ProfileWrapper } from './styles';
+import ProfileIcon from '../../../../../components/ProfileIcon';
+import Content from './Content';
+
+const PostText = ({ post }) => {
+  return (
+    <PostTextWrapper>
+      <ProfileWrapper>
+        <ProfileIcon />
+      </ProfileWrapper>
+      <Content post={post} />
+    </PostTextWrapper>
+  );
+};
+
+export default PostText;

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/styles.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/PostText/styles.js
@@ -1,0 +1,4 @@
+import PostTextWrapper from './PostTextWrapper';
+import ProfileWrapper from './ProfileWrapper';
+
+export { PostTextWrapper, ProfileWrapper };

--- a/web/src/containers/PostDetailPage/PostSideBox/PostContent/index.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/PostContent/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import PostContentWrapper from './PostContentWrapper';
+import PostText from './PostText';
+import CommentList from './CommentList';
+
+function PostContent({ post }) {
+  return (
+    <PostContentWrapper>
+      <PostText post={post} />
+      <CommentList PostId={+post.id} />
+    </PostContentWrapper>
+  );
+}
+
+export default PostContent;

--- a/web/src/containers/PostDetailPage/PostSideBox/SideBoxWrapper.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/SideBoxWrapper.js
@@ -1,0 +1,19 @@
+import styled, { css } from 'styled-components';
+
+const borderStyle = css`
+  ${({ theme }) => css`
+    border-left: solid 1px ${theme.palette.border};
+  `}}
+`;
+
+const SideBoxWrapper = styled.div`
+  flex: 1 0 auto;
+  width: 335px;
+  height: ${({ theme }) => theme.post_length}px;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  ${borderStyle}
+`;
+
+export default SideBoxWrapper;

--- a/web/src/containers/PostDetailPage/PostSideBox/UtilityBlock/IconList.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/UtilityBlock/IconList.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const IconList = styled.div`
+  width: 100%;
+  padding: 0 16px;
+  box-sizing: border-box;
+`;
+
+export default IconList;

--- a/web/src/containers/PostDetailPage/PostSideBox/UtilityBlock/IconWrapper.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/UtilityBlock/IconWrapper.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const IconWrapper = styled.span`
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+`;
+
+export default IconWrapper;

--- a/web/src/containers/PostDetailPage/PostSideBox/UtilityBlock/TimePassed.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/UtilityBlock/TimePassed.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+const TimePassed = styled.time`
+  color: ${({ theme }) => theme.palette.gray_font};
+  width: 100%;
+  padding: 0 16px;
+  box-sizing: border-box;
+  font-size: 10px;
+`;
+
+export default TimePassed;

--- a/web/src/containers/PostDetailPage/PostSideBox/UtilityBlock/UtilityBlockWrapper.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/UtilityBlock/UtilityBlockWrapper.js
@@ -1,0 +1,13 @@
+import styled, { css } from 'styled-components';
+
+const UtilityBlockWrapper = styled.div`
+  ${({ theme }) => {
+    const borderColor = theme.palette.border;
+    return css`
+      border-top: 1px solid ${borderColor};
+    `;
+  }}
+  padding-bottom:8px;
+`;
+
+export default UtilityBlockWrapper;

--- a/web/src/containers/PostDetailPage/PostSideBox/UtilityBlock/index.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/UtilityBlock/index.js
@@ -1,0 +1,64 @@
+import React, { useState, useCallback } from 'react';
+import _ from 'underscore';
+import { useMutation } from '@apollo/react-hooks';
+
+import Icon from '../../../../components/Icon';
+import { CREATE_POST_LIKE, DELETE_POST_LIKE } from '../../../../queries';
+import LikeIcon from '../../../../components/LikeIcon';
+import LikeInfo from '../../../../components/LikeInfo';
+import {
+  UtilityBlockWrapper,
+  IconList,
+  IconWrapper,
+  TimePassed,
+} from './styles';
+
+function UtilityBlock({ myInfo, post }) {
+  const [createPostLike] = useMutation(CREATE_POST_LIKE);
+  const [deletePostLike] = useMutation(DELETE_POST_LIKE);
+
+  const { id: postId, isLike, likerInfo, UserId } = post;
+  const [isLikeClicked, setLikeState] = useState(isLike);
+
+  const likeBtnClickHandler = () => {
+    const currentClickStatus = !isLikeClicked;
+    if (currentClickStatus)
+      createPostLike({
+        variables: { PostId: postId, WriterId: +UserId, UserId: myInfo.id },
+      });
+    else deletePostLike({ variables: { PostId: postId, UserId: myInfo.id } });
+  };
+
+  const lazyFetch = useCallback(_.debounce(likeBtnClickHandler, 1000), []);
+
+  const toggleLikeState = () => {
+    setLikeState(!isLikeClicked);
+    if (isLikeClicked !== isLike) return;
+    lazyFetch();
+  };
+
+  return (
+    <UtilityBlockWrapper>
+      <IconList>
+        <IconWrapper>
+          <LikeIcon isFull={isLikeClicked} onClick={toggleLikeState} />
+        </IconWrapper>
+        <IconWrapper>
+          <Icon ratio={5} posX={-520} posY={-245} />
+        </IconWrapper>
+        <IconWrapper>
+          <Icon ratio={5} posX={0} posY={-250} />
+        </IconWrapper>
+      </IconList>
+      <LikeInfo
+        myInfo={myInfo}
+        postId={postId}
+        diff={isLikeClicked - isLike}
+        likerInfo={likerInfo}
+      />
+      <TimePassed>1일 전</TimePassed>
+    </UtilityBlockWrapper>
+  );
+}
+
+export default UtilityBlock;

--- a/web/src/containers/PostDetailPage/PostSideBox/UtilityBlock/styles.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/UtilityBlock/styles.js
@@ -1,0 +1,6 @@
+import UtilityBlockWrapper from './UtilityBlockWrapper';
+import IconList from './IconList';
+import IconWrapper from './IconWrapper';
+import TimePassed from './TimePassed';
+
+export { UtilityBlockWrapper, IconList, IconWrapper, TimePassed };

--- a/web/src/containers/PostDetailPage/PostSideBox/context.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/context.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CommentContext = React.createContext({});
+
+export const CommentProvider = CommentContext.Provider;
+export const CommentConsumer = CommentContext.Consumer;
+export default CommentContext;

--- a/web/src/containers/PostDetailPage/PostSideBox/index.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/index.js
@@ -1,0 +1,22 @@
+import React, { useContext } from 'react';
+
+import SideBoxWrapper from './SideBoxWrapper';
+import PostTop from '../../../components/PostTop';
+import PostContent from './PostContent';
+import CommentInput from './CommentInput';
+import UtilityBlock from './UtilityBlock';
+import UserContext from '../../App/UserContext';
+
+function SideBox({ post }) {
+  const { myInfo } = useContext(UserContext);
+  return (
+    <SideBoxWrapper>
+      <PostTop myInfo={myInfo} writer={post.writer} postURL={post.postURL} />
+      <PostContent post={post} />
+      <UtilityBlock myInfo={myInfo} post={post} />
+      <CommentInput PostId={+post.id} />
+    </SideBoxWrapper>
+  );
+}
+
+export default SideBox;

--- a/web/src/containers/PostDetailPage/PostSideBox/reducer.js
+++ b/web/src/containers/PostDetailPage/PostSideBox/reducer.js
@@ -1,0 +1,41 @@
+import produce from 'immer';
+
+function reducer(state, action) {
+  switch (action.type) {
+    case 'LOADING':
+      return {
+        loading: true,
+        data: state.data || null,
+        error: null,
+      };
+    case 'SUCCESS':
+      return {
+        loading: false,
+        data: {
+          ...state.data,
+          commentList: state.data
+            ? state.data.commentList.concat(action.data.commentList)
+            : action.data.commentList,
+        },
+        error: null,
+      };
+    case 'ERROR':
+      return {
+        loading: false,
+        data: state.data || null,
+        error: action.error,
+      };
+    case 'NEWCOMMENT':
+      return produce(state, draft => {
+        draft.data.commentList.unshift({
+          id: action.id,
+          content: action.content,
+          writer: action.writer,
+        });
+      });
+    default:
+      throw new Error(`Unhandled action type: ${action.type}`);
+  }
+}
+
+export default reducer;

--- a/web/src/containers/PostDetailPage/ViewPort.js
+++ b/web/src/containers/PostDetailPage/ViewPort.js
@@ -1,0 +1,17 @@
+import styled, { css } from 'styled-components';
+
+const ViewPort = styled.div`
+  /* background */
+  ${({ img, theme }) => {
+    return css`
+      flex: 0 0 auto;
+      background-image: url(${img});
+      background-size: cover;
+      background-repeat: no-repeat;
+      width: ${theme.post_length}px;
+      height: ${theme.post_length}px;
+    `;
+  }}
+`;
+
+export default ViewPort;

--- a/web/src/containers/PostDetailPage/context.js
+++ b/web/src/containers/PostDetailPage/context.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const PostContext = React.createContext({});
+
+export const PostProvider = PostContext.Provider;
+export const PostConsumer = PostContext.Consumer;
+export default PostContext;

--- a/web/src/containers/PostDetailPage/index.js
+++ b/web/src/containers/PostDetailPage/index.js
@@ -1,0 +1,37 @@
+import React, { useContext } from 'react';
+import { ThemeProvider } from 'styled-components';
+import { useQuery } from '@apollo/react-hooks';
+
+import { PostDetailPageWrapper, ViewPort } from './styles';
+import PostSideBox from './PostSideBox';
+import { PostProvider } from './context';
+import { READ_POST } from '../../queries';
+import Loading from '../../components/Loading';
+import Error from '../../components/Error';
+import UserContext from '../App/UserContext';
+
+function PostDetailPage({ match }) {
+  const { myInfo } = useContext(UserContext);
+  const { loading, error, data } = useQuery(READ_POST, {
+    variables: { postURL: match.params.postURL, id: myInfo.id },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  if (loading) return <Loading size={50} />;
+  if (error) return <Error />;
+  if (!data) return null;
+  const { post } = data;
+
+  return (
+    <PostProvider value={{ data }}>
+      <ThemeProvider theme={{ post_length: 600 }}>
+        <PostDetailPageWrapper>
+          <ViewPort img={post.imageURL} />
+          <PostSideBox post={post} />
+        </PostDetailPageWrapper>
+      </ThemeProvider>
+    </PostProvider>
+  );
+}
+
+export default PostDetailPage;

--- a/web/src/containers/PostDetailPage/styles.js
+++ b/web/src/containers/PostDetailPage/styles.js
@@ -1,0 +1,4 @@
+import PostDetailPageWrapper from './PostDetailPageWrapper';
+import ViewPort from './ViewPort';
+
+export { PostDetailPageWrapper, ViewPort };

--- a/web/src/queries/commentList.js
+++ b/web/src/queries/commentList.js
@@ -1,0 +1,17 @@
+import { gql } from 'apollo-boost';
+
+const COMMENT_LIST = gql`
+  query CommentList($PostId: Int!, $offset: Int, $limit: Int) {
+    commentList(PostId: $PostId, offset: $offset, limit: $limit) {
+      id
+      content
+      updatedAt
+      writer {
+        username
+        profileImage
+      }
+    }
+  }
+`;
+
+export default COMMENT_LIST;

--- a/web/src/queries/createComment.js
+++ b/web/src/queries/createComment.js
@@ -1,0 +1,23 @@
+import { gql } from 'apollo-boost';
+
+const CREATE_COMMENT = gql`
+  mutation CreateComment($PostId: Int!, $UserId: Int!, $content: String!) {
+    createComment(
+      content: $content
+      depth: null
+      PostId: $PostId
+      UserId: $UserId
+    ) {
+      id
+      content
+      updatedAt
+      writer {
+        username
+        profileImage
+      }
+      PostId
+    }
+  }
+`;
+
+export default CREATE_COMMENT;

--- a/web/src/queries/createPostLike.js
+++ b/web/src/queries/createPostLike.js
@@ -1,0 +1,10 @@
+import { gql } from 'apollo-boost';
+
+const CREATE_POST_LIKE = gql`
+  mutation CreatePostLike($PostId: Int!, $WriterId: Int!, $UserId: Int!) {
+    createPostLike(
+      PostLike: { PostId: $PostId, WriterId: $WriterId, UserId: $UserId }
+    )
+  }
+`;
+export default CREATE_POST_LIKE;

--- a/web/src/queries/deletePostLike.js
+++ b/web/src/queries/deletePostLike.js
@@ -1,0 +1,9 @@
+import { gql } from 'apollo-boost';
+
+const DELETE_POST_LIKE = gql`
+  mutation DeletePostLike($PostId: Int!, $UserId: Int!) {
+    deletePostLike(PostLike: { PostId: $PostId, UserId: $UserId })
+  }
+`;
+
+export default DELETE_POST_LIKE;

--- a/web/src/queries/followingPostList.js
+++ b/web/src/queries/followingPostList.js
@@ -1,0 +1,35 @@
+import { gql } from 'apollo-boost';
+
+const FOLLOWING_POST_LIST = gql`
+  query FollowingPostList($myId: Int, $cursor: String, $limit: Int) {
+    followingPostList(id: $myId, cursor: $cursor, limit: $limit) {
+      id
+      imageURL
+      postURL
+      content
+      isLike
+      updatedAt
+      UserId
+      writer {
+        username
+        isFollow
+        profileImage
+      }
+      commentCount
+      commentList {
+        id
+        content
+        writer {
+          username
+        }
+      }
+      likerInfo {
+        likerCount
+        username
+        profileImage
+      }
+    }
+  }
+`;
+
+export default FOLLOWING_POST_LIST;

--- a/web/src/queries/getLogs.js
+++ b/web/src/queries/getLogs.js
@@ -1,0 +1,22 @@
+import { gql } from 'apollo-boost';
+
+const GET_LOGS = gql`
+  query Log($id: Int!) {
+    log(id: $id) {
+      status
+      fromUser {
+        username
+        profileImage
+        follow {
+          status
+        }
+      }
+      post {
+        postURL
+        imageURL
+      }
+    }
+  }
+`;
+
+export default GET_LOGS;

--- a/web/src/queries/index.js
+++ b/web/src/queries/index.js
@@ -1,0 +1,23 @@
+import FOLLOWING_POST_LIST from './followingPostList';
+import CREATE_COMMENT from './createComment';
+import CREATE_POST_LIKE from './createPostLike';
+import DELETE_POST_LIKE from './deletePostLike';
+import COMMENT_LIST from './commentList';
+import READ_POST from './readPost';
+import UPDATE_USER from './updateUser';
+import LIKER_LIST from './likerList';
+import GET_LOGS from './getLogs';
+import SEARCH from './search';
+
+export {
+  FOLLOWING_POST_LIST,
+  CREATE_COMMENT,
+  CREATE_POST_LIKE,
+  DELETE_POST_LIKE,
+  COMMENT_LIST,
+  READ_POST,
+  UPDATE_USER,
+  LIKER_LIST,
+  GET_LOGS,
+  SEARCH,
+};

--- a/web/src/queries/likerList.js
+++ b/web/src/queries/likerList.js
@@ -1,0 +1,15 @@
+import { gql } from 'apollo-boost';
+
+const LIKER_LIST = gql`
+  query LikerList($postId: Int!) {
+    likerList(postId: $postId) {
+      id
+      username
+      name
+      profileImage
+      followStatus
+    }
+  }
+`;
+
+export default LIKER_LIST;

--- a/web/src/queries/readPost.js
+++ b/web/src/queries/readPost.js
@@ -1,0 +1,35 @@
+import { gql } from 'apollo-boost';
+
+const READ_POST = gql`
+  query Post($postURL: String!, $id: ID!) {
+    post(postURL: $postURL, id: $id) {
+      id
+      imageURL
+      postURL
+      content
+      isLike
+      updatedAt
+      UserId
+      writer {
+        username
+        isFollow
+        profileImage
+      }
+      commentCount
+      commentList {
+        id
+        content
+        writer {
+          username
+        }
+      }
+      likerInfo {
+        likerCount
+        username
+        profileImage
+      }
+    }
+  }
+`;
+
+export default READ_POST;

--- a/web/src/queries/search.js
+++ b/web/src/queries/search.js
@@ -1,0 +1,14 @@
+import { gql } from 'apollo-boost';
+
+const SEARCH = gql`
+  query Search($value: String) {
+    search(value: $value) {
+      id
+      username
+      name
+      profileImage
+    }
+  }
+`;
+
+export default SEARCH;

--- a/web/src/queries/updateUser.js
+++ b/web/src/queries/updateUser.js
@@ -1,0 +1,26 @@
+import { gql } from 'apollo-boost';
+
+const UPDATE_USER = gql`
+  mutation UpdateUser(
+    $id: ID!
+    $name: String
+    $username: String
+    $email: String
+    $cellPhone: String
+  ) {
+    updateUser(
+      id: $id
+      name: $name
+      username: $username
+      email: $email
+      cellPhone: $cellPhone
+    ) {
+      name
+      username
+      email
+      cellPhone
+    }
+  }
+`;
+
+export default UPDATE_USER;


### PR DESCRIPTION
안녕하세요 리뷰어님🙂 먼저, 리뷰 질문이 늦어 죄송합니다ㅜ

최근에 저희 팀은 아폴로 클라이언트를 도입하였는데요, 캐싱 관리에 관하여 여쭈어 볼 것이 있어서 질문 드립니다.

메인 페이지와 상세 페이지는 겹치는 내용이 꽤나 존재하는데요, 이를 캐싱 전략에 활용하면 좋을 것 같은데 어떠한 방법으로 해야할지 몰라 고민중입니다.

예시들 들어서 상황을 설명하겠습니다.

[Main Page]
![image](https://user-images.githubusercontent.com/40619551/70846659-02925800-1e9f-11ea-95e0-f06b2db63481.png)
    
    
    
<br/>
<br/>

[Detail Page]
![image](https://user-images.githubusercontent.com/40619551/70846675-1f2e9000-1e9f-11ea-85c6-0f8e75054dcf.png)


위 그림에서 메인 페이지에 먼저 접근한 후, 상세 페이지로 이동하는 경우를 가정하겠습니다.

현재의 구조에서는 최초 메인페이지에 접근 할 때에 게시글 리스트를 요청하고 상세 페이지로 이동하면, 
상세 페이지에 대한 데이터를 또 다시 요청합니다.

그런데 상세 페이지의 대부분의 정보는 메인 페이지에 들어 있는 상황입니다. 따라서 상세 페이지를 로드할 때에, 캐시안에 존재하는 메인 페이지 리스트에 해당 상세 페이지가 들어있는 경우에는, 요청을 새로 보내지 않고 메인 페이지 리스트에서 해당 내용을 뽑아서 사용하는 것을 구상하고 있습니다.

하지만 아폴로 클라이언트는 적어도 제가 이해하고 있는 한, `요청 단위`로 캐싱이 되기 때문에, 단순히 useQuery를 이용할 경우엔, 게시글 리스트에 대한 요청과 게시글 상세 페이지에 대한 요청이 다르기 때문에 캐시가 공유되지 않아 매번 새롭게 요청을 보냅니다.

이 부분에 대한 해결책으로, 메인페이지에서 게시글을 로드할 때에, 우선 게시글 목록 (게시글 id의 리스트) 를 먼저 요청을 통해서 받고, 받은 id를 통해 각각의 게시글에 대한 요청을 보낸다면, 어느정도 해결될 것이라고 봅니다. 하지만 메인 페이지에 렌더링 될 정보를 한 번의 요청으로 받아오지 않고, 매번 여러번의 요청으로 쪼개어서 보내는 방법은 옳지 않다는 의견들을 받아 현재는 캐시를 활용하지 못하고 있는 상황입니다.