### PR TITLE
[팔로우버튼, 유저페이지] 팔로우버튼 정상작동 구현, UserPage 팔로우 데이터 즉각 반영 구현

### DIFF
--- a/api-server/api/graphql/mutations/RequestFollowing.js
+++ b/api-server/api/graphql/mutations/RequestFollowing.js
@@ -1,7 +1,7 @@
 const { GraphQLInt } = require('graphql');
 
 const { UserFollower } = require('../types');
-const { UserFollow } = require('../../../db');
+const { createFollowData } = require('../../services/RequestFollowingService');
 
 const RequestFollowing = {
   type: UserFollower,
@@ -9,14 +9,14 @@ const RequestFollowing = {
     myId: { type: GraphQLInt },
     userId: { type: GraphQLInt },
   },
-  resolve: async (obj, { myId, userId }) => {
-    const userFollower = await UserFollow.create({
-      from: myId,
-      to: userId,
-      status: 0,
-      updatedAt: new Date(),
-    });
-    return userFollower;
+  resolve: async (_, args) => {
+    try {
+      const userFollower = await createFollowData(args);
+      return userFollower;
+    } catch (e) {
+      console.log(e.message);
+      return { error: e.message };
+    }
   },
 };
 

--- a/api-server/api/graphql/mutations/RequestFollowingCancellation.js
+++ b/api-server/api/graphql/mutations/RequestFollowingCancellation.js
@@ -1,7 +1,9 @@
 const { GraphQLInt } = require('graphql');
 
 const { UserFollower } = require('../types');
-const { UserFollow } = require('../../../db');
+const {
+  destroyFollowCancellationData,
+} = require('../../services/RequestFollowingCancellationService');
 
 const RequestFollowingCancellation = {
   type: UserFollower,
@@ -9,14 +11,16 @@ const RequestFollowingCancellation = {
     myId: { type: GraphQLInt },
     userId: { type: GraphQLInt },
   },
-  resolve: async (obj, { myId, userId }) => {
-    const userFollowerCancellation = await UserFollow.destroy({
-      where: {
-        from: myId,
-        to: userId,
-      },
-    });
-    return userFollowerCancellation;
+  resolve: async (_, args) => {
+    try {
+      const userFollowerCancellation = await destroyFollowCancellationData(
+        args,
+      );
+      return userFollowerCancellation;
+    } catch (e) {
+      console.log(e.message);
+      return { error: e.message };
+    }
   },
 };
 

--- a/api-server/api/graphql/queries/UserPageQuery.js
+++ b/api-server/api/graphql/queries/UserPageQuery.js
@@ -9,7 +9,7 @@ const userPageQuery = {
     username: { type: GraphQLString },
     myId: { type: GraphQLInt },
   },
-  resolve: async (post, args) => {
+  resolve: async (_, args) => {
     try {
       const data = await getUserPageData(args);
       return data;

--- a/api-server/api/graphql/types/UserInfoType.js
+++ b/api-server/api/graphql/types/UserInfoType.js
@@ -1,9 +1,4 @@
-const {
-  GraphQLObjectType,
-  GraphQLString,
-  GraphQLBoolean,
-  GraphQLInt,
-} = require('graphql');
+const { GraphQLObjectType, GraphQLString, GraphQLInt } = require('graphql');
 
 const UserInfoType = new GraphQLObjectType({
   name: 'userInfo',
@@ -21,7 +16,7 @@ const UserInfoType = new GraphQLObjectType({
       resolve: userInfo => userInfo.profileImage,
     },
     isFollowing: {
-      type: GraphQLBoolean,
+      type: GraphQLInt,
       resolve: userInfo => userInfo.isFollowing,
     },
     postNumber: {

--- a/api-server/api/services/RequestFollowingCancellationService.js
+++ b/api-server/api/services/RequestFollowingCancellationService.js
@@ -1,0 +1,29 @@
+const { UserFollow, Log } = require('../../db');
+
+const deleteFollow = async (myId, userId) => {
+  const userFollowerCancellation = await UserFollow.destroy({
+    where: {
+      from: myId,
+      to: userId,
+    },
+  });
+  return userFollowerCancellation;
+};
+
+const deleteFollowLog = (myId, userId) => {
+  Log.destroy({
+    where: {
+      From: myId,
+      To: userId,
+      status: 'follow',
+    },
+  });
+};
+
+const destroyFollowCancellationData = async ({ myId, userId }) => {
+  const userFollowerCancellation = await deleteFollow(myId, userId);
+  await deleteFollowLog(myId, userId);
+  return userFollowerCancellation;
+};
+
+module.exports = { destroyFollowCancellationData };

--- a/api-server/api/services/RequestFollowingService.js
+++ b/api-server/api/services/RequestFollowingService.js
@@ -1,0 +1,26 @@
+const { UserFollow, Log } = require('../../db');
+
+const insertFollow = async (myId, userId) => {
+  const userFollower = await UserFollow.create({
+    from: myId,
+    to: userId,
+    status: 0,
+  });
+  return userFollower;
+};
+
+const insertFollowLog = async (myId, userId) => {
+  await Log.create({
+    From: myId,
+    To: userId,
+    status: 'follow',
+  });
+};
+
+const createFollowData = async ({ myId, userId }) => {
+  const userFollower = await insertFollow(myId, userId);
+  await insertFollowLog(myId, userId);
+  return userFollower;
+};
+
+module.exports = { createFollowData };

--- a/api-server/api/services/UserPageService.js
+++ b/api-server/api/services/UserPageService.js
@@ -9,13 +9,15 @@ const getUserInfo = async username => {
 };
 
 const checkFollowing = async (userId, myId) => {
-  const isFollowing = await UserFollow.count({
+  const isFollowing = await UserFollow.findOne({
+    attributes: ['status'],
     where: {
       from: myId,
       to: userId,
     },
   });
-  return !!isFollowing;
+  const result = isFollowing ? isFollowing.status : isFollowing;
+  return result;
 };
 
 const getFollowersNum = async userId => {

--- a/web/src/components/FollowButton/index.js
+++ b/web/src/components/FollowButton/index.js
@@ -5,8 +5,17 @@ import { useMutation } from '@apollo/react-hooks';
 import StyledFollowButton from './StyledFollowButton';
 import FollowCheckingModal from '../FollowCheckingModal';
 
-const FollowButton = ({ followStatus, className, username, myId, userId }) => {
+const FollowButton = ({
+  followStatus,
+  className,
+  username,
+  myId,
+  userId,
+  onFollowCancel,
+  onFollow,
+}) => {
   // folowStatus {null: 팔로우하고있지 않은 상태(팔로우하지 않을 때 삭제? 0?), 0: 팔로우하고 있는 상태, 1: 비공개 계정에 요청한 상태}
+  // 팔로우 취소 또는 팔로우시 로컬에 반영되어야할 일이 있으면 함수형태로 onFollowCancel, onFollow에 props를 내려주면 됨.
   const [currentFollowStatus, setCurrentFollowStatus] = useState(followStatus);
   const [isVisible, setIsVisible] = useState(false);
 
@@ -39,6 +48,7 @@ const FollowButton = ({ followStatus, className, username, myId, userId }) => {
   const cancelFollowing = () => {
     requestFollowingCancellation({ variables: { myId, userId } });
     setCurrentFollowStatus(null);
+    if (onFollowCancel) onFollowCancel();
     onClick();
   };
 
@@ -47,14 +57,15 @@ const FollowButton = ({ followStatus, className, username, myId, userId }) => {
       case null:
         requestFollowing({ variables: { myId, userId } });
         setCurrentFollowStatus(0);
+        if (onFollow) onFollow();
+        break;
+      case 0:
+        setIsVisible(isVisible => !isVisible);
         break;
       // case 1:
       //   setCurrentFollowStatus('팔로잉');
       //   setIsVisible(isVisible => !isVisible);
       //   break;
-      case 0:
-        setIsVisible(isVisible => !isVisible);
-        break;
       default:
         throw new Error(
           `Current follow status is wrong : ${currentFollowStatus}`,

--- a/web/src/components/FollowButton/index.js
+++ b/web/src/components/FollowButton/index.js
@@ -43,7 +43,7 @@ const FollowButton = ({
     requestFollowingCancellationQuery,
   );
 
-  const onClick = () => setIsVisible(isVisible => !isVisible);
+  const onClick = () => setIsVisible(prevVisibleStatus => !prevVisibleStatus);
 
   const cancelFollowing = () => {
     requestFollowingCancellation({ variables: { myId, userId } });
@@ -60,7 +60,7 @@ const FollowButton = ({
         if (onFollow) onFollow();
         break;
       case 0:
-        setIsVisible(isVisible => !isVisible);
+        setIsVisible(prevVisibleStatus => !prevVisibleStatus);
         break;
       // case 1:
       //   setCurrentFollowStatus('팔로잉');

--- a/web/src/components/FollowButton/index.js
+++ b/web/src/components/FollowButton/index.js
@@ -63,8 +63,7 @@ const FollowButton = ({
         setIsVisible(prevVisibleStatus => !prevVisibleStatus);
         break;
       // case 1:
-      //   setCurrentFollowStatus('팔로잉');
-      //   setIsVisible(isVisible => !isVisible);
+      //   추후 요청됨 구현 시 로직 추가
       //   break;
       default:
         throw new Error(

--- a/web/src/containers/UserPage/UserPageInfo/UserInfo/index.js
+++ b/web/src/containers/UserPage/UserPageInfo/UserInfo/index.js
@@ -14,10 +14,24 @@ import {
   NameWrapper,
 } from './styles';
 
-const UserInfo = ({ username, myId, data, isMyPage }) => {
+const UserInfo = ({
+  username,
+  myId,
+  data,
+  isMyPage,
+  onFollowCancel,
+  onFollow,
+}) => {
   const btnStyle = 'light';
   let button = (
-    <StyledFollowButton username={username} myId={myId} userId={data.id} />
+    <StyledFollowButton
+      followStatus={data.isFollowing}
+      username={username}
+      myId={myId}
+      userId={data.id}
+      onFollowCancel={onFollowCancel}
+      onFollow={onFollow}
+    />
   );
   if (isMyPage)
     button = (

--- a/web/src/containers/UserPage/UserPageInfo/index.js
+++ b/web/src/containers/UserPage/UserPageInfo/index.js
@@ -4,7 +4,14 @@ import ProfileIcon from '../../../components/ProfileIcon';
 import UserInfo from './UserInfo';
 import { UserPageInfoWrapper, ProfileIconWrapper } from './styles';
 
-const UserPageInfo = ({ username, myId, data, isMyPage }) => {
+const UserPageInfo = ({
+  username,
+  myId,
+  data,
+  isMyPage,
+  onFollowCancel,
+  onFollow,
+}) => {
   return (
     <UserPageInfoWrapper>
       <ProfileIconWrapper>
@@ -15,6 +22,8 @@ const UserPageInfo = ({ username, myId, data, isMyPage }) => {
         myId={myId}
         data={data}
         isMyPage={isMyPage}
+        onFollowCancel={onFollowCancel}
+        onFollow={onFollow}
       />
     </UserPageInfoWrapper>
   );


### PR DESCRIPTION
- 팔로우버튼의 팔로우 기능이 정확하게 동작하도록 요청 변경, UserPage에서 팔로우 취소 및 팔로우 시 즉각적으로 반영되도록 변경
- 팔로우를 할 때는 로그 테이블에 등록되어 상대방에게 알람이 가야하고 팔로우를 취소할 떄는 로그테이블에서 삭제되어 알람이 가지 않아야한다. 팔로우 또는 팔로우 취소시 로그테이블에 로우를 추가 및 삭제하여 해당 기능을 구현.