### PR TITLE
[Fix] 게시물이 최신글부터 리스트되도록 수정

### DIFF
--- a/api-server/api/services/HashTagPageService.js
+++ b/api-server/api/services/HashTagPageService.js
@@ -14,6 +14,7 @@ const getPostIds = async hashTagId => {
     where: {
       HashTagId: hashTagId.id,
     },
+    order: [['updatedAt', 'DESC']],
   });
   return postIds;
 };

--- a/api-server/api/services/UserPageService.js
+++ b/api-server/api/services/UserPageService.js
@@ -37,6 +37,7 @@ const getFollowsNum = async userId => {
 const getPostCard = async userId => {
   const postCard = await Post.findAll({
     where: { UserId: userId },
+    order: [['updatedAt', 'DESC']],
   });
   return postCard;
 };


### PR DESCRIPTION
유저페이지와 해쉬태그페이지에서 오래된 게시물부터 보이는 버그가
있었음. updatedAt을 DESC로 order by하여 최신글이 위로 올라오도록
수정함.