### PR TITLE
[Fix] post card에 배경색 추가

### DIFF
--- a/web/src/components/PostCardList/PostCardLine/PostCard/MarginalPostCard.js
+++ b/web/src/components/PostCardList/PostCardLine/PostCard/MarginalPostCard.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 const MarginalPostCard = styled.div`
+  background-color: white;
   margin-right: 28px;
   &:last-child {
     margin-right: 0px;


### PR DESCRIPTION
게시된 이미지에 배경색이 없는 경우 post card의 영역이 명확하게
구분되지 않는다는 의견이 있어 기본적으로 흰색 배경을 부여함.