### PR TITLE
[Fix] hashtag가 최대 44글자까지 파싱되도록 수정

### DIFF
--- a/web/src/containers/HomePage/Post/PostText/MainText/lib/index.js
+++ b/web/src/containers/HomePage/Post/PostText/MainText/lib/index.js
@@ -4,6 +4,7 @@ import StyledLink from '../../../../../../components/StyledLink';
 
 export function parseMainText(content) {
   let isTag = false;
+  let isHashTag = false;
   const result = Array.from(content).reduce(
     (acc, char) => {
       if (isTag && char === ' ') {
@@ -14,7 +15,18 @@ export function parseMainText(content) {
       if (char !== '@' && char !== '#') {
         const { length } = acc;
         const last = acc[length - 1].concat(char);
+
+        if (isHashTag && last.length > 45) {
+          isTag = false;
+          isHashTag = false;
+          return [...acc, char];
+        }
+
         return [...acc.slice(0, length - 1), last];
+      }
+
+      if (char === '#') {
+        isHashTag = true;
       }
 
       isTag = true;


### PR DESCRIPTION
- '#'을 제외한 hashtag의 최대길이가 44글자이므로 파싱이 44글자이상 되지 않도록 수정.