### PR TITLE
[Fix] graphql type때문에 생긴 오류 수정

### DIFF
--- a/api-server/api/graphql/mutations/UserMutation.js
+++ b/api-server/api/graphql/mutations/UserMutation.js
@@ -64,7 +64,7 @@ const updateProfile = {
       type: GraphQLUpload,
     },
     userId: {
-      type: GraphQLInt,
+      type: GraphQLID,
     },
   },
   resolve: async (_, { file, userId }) => {


### PR DESCRIPTION
graphql 파일들 리팩토링 과정에서 int를 ID로 바꾸지 않은 파일이 있어
생긴 오류 수정.