### PR TITLE
[Refact] UserListModal에서 본인 계정의 FollowButton 렌더링 방지

### DIFF
--- a/web/src/components/UserListModal/UserListItem/index.js
+++ b/web/src/components/UserListModal/UserListItem/index.js
@@ -8,6 +8,19 @@ const UserListItem = ({ userInfo, myId }) => {
   const { id, name, username, profileImage, isFollow } = userInfo;
   const profileImageRatio = 9.375;
   const userpageURL = `/${username}`;
+
+  const getFollowButton = () => {
+    if (myId === Number(id)) return <></>;
+    return (
+      <FollowButton
+        followStatus={isFollow}
+        username={username}
+        myId={myId}
+        userId={id}
+      />
+    );
+  };
+
   return (
     <li>
       <StyledLink to={userpageURL}>
@@ -19,14 +32,7 @@ const UserListItem = ({ userInfo, myId }) => {
         </div>
         <span>{name}</span>
       </section>
-      <div>
-        <FollowButton
-          followStatus={isFollow}
-          username={username}
-          myId={myId}
-          userId={id}
-        />
-      </div>
+      <div>{getFollowButton()}</div>
     </li>
   );
 };


### PR DESCRIPTION
기존의 UserListModal에서는 본인 계정에도 FollowButton을 렌더링했음.
하지만 본인계정을 팔로우하는 기능은 제공하지 않기 때문에 렌더링하지
않도록 수정.