### PR TITLE
[Fix] 게시물 수정시 새로운 해시태그 및 유저태그 반영되도록 수정

### DIFF
--- a/api-server/api/graphql/mutations/PostMutation.js
+++ b/api-server/api/graphql/mutations/PostMutation.js
@@ -6,6 +6,7 @@ const { Post } = require('../../../db');
 const {
   insertPost,
   insertHashTagOfPost,
+  insertUserTag,
 } = require('../../services/PostService');
 const s3 = require('../../../upload');
 
@@ -97,6 +98,7 @@ const updatePost = {
         },
       );
       await insertHashTagOfPost(content, id);
+      await insertUserTag(content, id);
       return { id, content };
     } catch (error) {
       console.log(error.message);

--- a/api-server/api/graphql/mutations/PostMutation.js
+++ b/api-server/api/graphql/mutations/PostMutation.js
@@ -3,11 +3,7 @@ const { GraphQLUpload } = require('graphql-upload');
 
 const { PostType } = require('../types');
 const { Post } = require('../../../db');
-const {
-  insertPost,
-  insertHashTagOfPost,
-  insertUserTag,
-} = require('../../services/PostService');
+const { insertPost, updatePostInfo } = require('../../services/PostService');
 const s3 = require('../../../upload');
 
 const createPost = {
@@ -87,23 +83,7 @@ const updatePost = {
       type: new GraphQLNonNull(GraphQLID),
     },
   },
-  resolve: async (_, { id, content }) => {
-    try {
-      await Post.update(
-        { content },
-        {
-          where: {
-            id,
-          },
-        },
-      );
-      await insertHashTagOfPost(content, id);
-      await insertUserTag(content, id);
-      return { id, content };
-    } catch (error) {
-      console.log(error.message);
-    }
-  },
+  resolve: async (_, { id, content }) => await updatePostInfo(content, id),
 };
 
 module.exports = {

--- a/api-server/api/graphql/mutations/PostMutation.js
+++ b/api-server/api/graphql/mutations/PostMutation.js
@@ -3,7 +3,10 @@ const { GraphQLUpload } = require('graphql-upload');
 
 const { PostType } = require('../types');
 const { Post } = require('../../../db');
-const { insertPost } = require('../../services/PostService');
+const {
+  insertPost,
+  insertHashTagOfPost,
+} = require('../../services/PostService');
 const s3 = require('../../../upload');
 
 const createPost = {
@@ -84,15 +87,20 @@ const updatePost = {
     },
   },
   resolve: async (_, { id, content }) => {
-    await Post.update(
-      { content },
-      {
-        where: {
-          id,
+    try {
+      await Post.update(
+        { content },
+        {
+          where: {
+            id,
+          },
         },
-      },
-    );
-    return { id, content };
+      );
+      await insertHashTagOfPost(content, id);
+      return { id, content };
+    } catch (error) {
+      console.log(error.message);
+    }
   },
 };
 

--- a/api-server/api/services/PostService.js
+++ b/api-server/api/services/PostService.js
@@ -218,6 +218,24 @@ async function insertHashTagOfPost(content, postId) {
   });
 }
 
+async function updatePostInfo(content, id) {
+  try {
+    await Post.update(
+      { content },
+      {
+        where: {
+          id,
+        },
+      },
+    );
+    await insertHashTagOfPost(content, id);
+    await insertUserTag(content, id);
+    return { id, content };
+  } catch (error) {
+    console.log(error.message);
+  }
+}
+
 module.exports = {
   getFollowingPostList,
   checkUserLikePost,
@@ -228,4 +246,5 @@ module.exports = {
   insertPost,
   insertHashTagOfPost,
   insertUserTag,
+  updatePostInfo,
 };

--- a/api-server/api/services/PostService.js
+++ b/api-server/api/services/PostService.js
@@ -227,4 +227,5 @@ module.exports = {
   unsetPostLike,
   insertPost,
   insertHashTagOfPost,
+  insertUserTag,
 };

--- a/api-server/api/services/PostService.js
+++ b/api-server/api/services/PostService.js
@@ -226,4 +226,5 @@ module.exports = {
   setPostLike,
   unsetPostLike,
   insertPost,
+  insertHashTagOfPost,
 };


### PR DESCRIPTION
게시물 수정시 새로운 해시태그일 경우에 해시태그 테이블에 insert되지
않아서 게시물이 검색이 안되는 경우가 생겨 테이블에 insert하도록 수정.

새로운 유저태그일 경우에 유저태그 테이블에 insert되지 않아서 
게시물이 검색이 안되는 경우가 생겨 테이블에 insert하도록 수정.