### PR TITLE
[Fix] more modal에서 팔로우 취소 버튼 제거

### DIFF
--- a/api-server/api/graphql/types/UserType.js
+++ b/api-server/api/graphql/types/UserType.js
@@ -1,13 +1,4 @@
-const {
-  GraphQLObjectType,
-  GraphQLString,
-  GraphQLID,
-  GraphQLInt,
-} = require('graphql');
-const {
-  UserFollow,
-  Sequelize: { Op },
-} = require('../../../db');
+const { GraphQLObjectType, GraphQLString, GraphQLID } = require('graphql');
 
 const UserType = new GraphQLObjectType({
   name: 'User',
@@ -29,9 +20,6 @@ const UserType = new GraphQLObjectType({
     },
     profileImage: {
       type: GraphQLString,
-    },
-    isFollow: {
-      type: GraphQLInt,
     },
   }),
 });

--- a/web/src/components/PostTop/MoreModal/index.js
+++ b/web/src/components/PostTop/MoreModal/index.js
@@ -3,9 +3,8 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { useMutation } from '@apollo/react-hooks';
 import { Redirect } from 'react-router-dom';
 
-import { ModalContent, StyledLink, Modal, FollowCancelContent } from './styles';
+import { ModalContent, StyledLink, Modal } from './styles';
 import { DELETE_POST, FOLLOWING_POST_LIST } from '../../../queries';
-import CustomFollowButton from './styles/CustomFollowButton';
 
 const MoreModal = ({ isVisible, setIsVisible, writer, myInfo, postURL }) => {
   const [redirect, setRedirect] = useState(false);
@@ -49,21 +48,6 @@ const MoreModal = ({ isVisible, setIsVisible, writer, myInfo, postURL }) => {
   if (!isVisible) return null;
   return (
     <Modal onClick={clickClose}>
-      {writer.username !== myInfo.username && writer.isFollow === 0 && (
-        <ModalContent>
-          <FollowCancelContent htmlFor="follow_cancel">
-            팔로우 취소
-          </FollowCancelContent>
-          <CustomFollowButton
-            id="follow_cancel"
-            followStatus={writer.isFollow}
-            username={writer.username}
-            myId={myInfo.id}
-            userId={writer.id}
-            onFollowCancel={clickClose}
-          />
-        </ModalContent>
-      )}
       {writer.username === myInfo.username && (
         <>
           <StyledLink to={`/edit/${postURL}`}>

--- a/web/src/queries/followingPostList.js
+++ b/web/src/queries/followingPostList.js
@@ -12,7 +12,6 @@ const FOLLOWING_POST_LIST = gql`
       writer {
         id
         username
-        isFollow
         profileImage
       }
       commentCount

--- a/web/src/queries/readPost.js
+++ b/web/src/queries/readPost.js
@@ -13,7 +13,6 @@ const READ_POST = gql`
       writer {
         id
         username
-        isFollow
         profileImage
       }
       likerInfo {


### PR DESCRIPTION
메인페이지와 디테일 페이지 모두 post type을 반환하는데 구조상 팔로우
여부를 반환하는 것이 성능 저하를 일으켜 팔로우 취소 버튼 체거.