### PR TITLE
[Refact] 팔로우, 팔로워 조회시 쿼리 최적화

### DIFF
--- a/api-server/api/graphql/queries/FollowListQuery.js
+++ b/api-server/api/graphql/queries/FollowListQuery.js
@@ -34,10 +34,7 @@ const followListQuery = {
   resolve: async (_, args) => {
     const followList = await getFollowList(args);
     const followIdList = getFollowIdList(followList);
-    const followDataList = await getFollowDataList({
-      followIdList,
-      ...args,
-    });
+    const followDataList = await getFollowDataList(followIdList, args);
     const followUpdatedDataList = await getFollowUpdatedDataList(
       followDataList,
       args,

--- a/api-server/api/graphql/queries/FollowerListQuery.js
+++ b/api-server/api/graphql/queries/FollowerListQuery.js
@@ -34,10 +34,7 @@ const followerListQuery = {
   resolve: async (_, args) => {
     const followerList = await getFollowerList(args);
     const followerIdList = getFollowerIdList(followerList);
-    const followerDataList = await getFollowDataList({
-      followerIdList,
-      ...args,
-    });
+    const followerDataList = await getFollowDataList(followerIdList, args);
     const followerUpdatedDataList = await getFollowUpdatedDataList(
       followerDataList,
       args,


### PR DESCRIPTION
기존이 쿼리는 시퀄라이즈가 여러번 데이터베이스에 요청을 보내
커넥션을 생성하고 제거하는데 코스트가 컸다. 그러한 코스트를 줄이기
위해 하나의 쿼리로 원하는 결과값을 얻도록 수정.