### PR TITLE
[Fix] 팔로우 취소때 상대방의 프로필 사진이 뜨도록 수정

### DIFF
--- a/web/src/components/FollowButton/index.js
+++ b/web/src/components/FollowButton/index.js
@@ -17,6 +17,7 @@ const FollowButton = ({
   userId,
   onFollowCancel,
   onFollow,
+  userProfileImage,
 }) => {
   const [currentFollowStatus, setCurrentFollowStatus] = useState(followStatus);
   const [isVisible, setIsVisible] = useState(false);
@@ -83,6 +84,7 @@ const FollowButton = ({
         onClick={onClick}
         cancelFollowing={cancelFollowing}
         username={username}
+        userProfileImage={userProfileImage}
       />
     </>
   );

--- a/web/src/components/FollowCheckingModal/index.js
+++ b/web/src/components/FollowCheckingModal/index.js
@@ -23,6 +23,7 @@ const FollowCheckingModal = ({
   onClick,
   cancelFollowing,
   username,
+  userProfileImage,
 }) => {
   const stopPropagation = e => e.stopPropagation();
   if (!isVisible) return <></>;
@@ -31,7 +32,7 @@ const FollowCheckingModal = ({
       <ModalWrapper onClick={stopPropagation} style={modalWrapperStyle}>
         <ModalContent>
           <div style={modalHeaderStyle}>
-            <ProfileIcon ratio={28.125} />
+            <ProfileIcon ratio={20} imageURL={userProfileImage} />
             <ModalHeaderText>
               @{username}님의 팔로우를 취소하시겠어요?
             </ModalHeaderText>

--- a/web/src/components/UserListModal/UserListItem/index.js
+++ b/web/src/components/UserListModal/UserListItem/index.js
@@ -18,6 +18,7 @@ const UserListItem = ({ userInfo, myId, ...props }) => {
         username={username}
         myId={myId}
         userId={id}
+        userProfileImage={profileImage}
       />
     );
   };

--- a/web/src/containers/Navigation/Alarm/AlarmToolTip/AlarmResult/index.js
+++ b/web/src/containers/Navigation/Alarm/AlarmToolTip/AlarmResult/index.js
@@ -30,6 +30,7 @@ const AlarmResult = ({ result, isLast, clickClose, cookies }) => {
           username={result.fromUser.username}
           myId={myInfo.id}
           userId={result.fromUser.id}
+          userProfileImage={result.fromUser.profileImage}
         />
       );
       break;

--- a/web/src/containers/UserPage/UserPageInfo/UserInfo/index.js
+++ b/web/src/containers/UserPage/UserPageInfo/UserInfo/index.js
@@ -21,6 +21,7 @@ const UserInfo = ({
   isMyPage,
   onFollowCancel,
   onFollow,
+  userProfileImage,
 }) => {
   const btnStyle = 'light';
   let button = (
@@ -31,6 +32,7 @@ const UserInfo = ({
       userId={data.id}
       onFollowCancel={onFollowCancel}
       onFollow={onFollow}
+      userProfileImage={userProfileImage}
     />
   );
   if (isMyPage)

--- a/web/src/containers/UserPage/UserPageInfo/index.js
+++ b/web/src/containers/UserPage/UserPageInfo/index.js
@@ -24,6 +24,7 @@ const UserPageInfo = ({
         isMyPage={isMyPage}
         onFollowCancel={onFollowCancel}
         onFollow={onFollow}
+        userProfileImage={data.profileImage}
       />
     </UserPageInfoWrapper>
   );


### PR DESCRIPTION
팔로우 취소를 확인하는 모달에 상대방의 프로필 사진이 뜨지않아
상대방의 프로필 사진이 뜨도록 props를 내려주게 수정.