### PR TITLE
[Fix] 새게시물 너무 큰 이미지는 전송하지 않도록  수정

### DIFF
--- a/web/src/containers/NewPostPage/index.js
+++ b/web/src/containers/NewPostPage/index.js
@@ -110,6 +110,11 @@ const NewPostPage = ({ cookies }) => {
       return;
     }
 
+    if (state.originalImage.size > 4500000) {
+      toast('5MB 이하의 파일만 업로드 할 수 있습니다!');
+      return;
+    }
+
     try {
       setLoading(true);
       const croppedImageFile = await makeNewImageFile(state);


### PR DESCRIPTION
새게시물 등록시 5MB가 넘는 파일은 전송하지 않도록 수정.