### PR TITLE
[Fix] 사용하지 않는 페이지라 사용되지 않는 코드 삭제

### DIFF
--- a/web/src/containers/App/index.js
+++ b/web/src/containers/App/index.js
@@ -20,7 +20,6 @@ const HashTagPage = lazy(() => import('../HashTagPage'));
 const SettingPage = lazy(() => import('../SettingPage'));
 const UserPage = lazy(() => import('../UserPage'));
 const EditProfilePage = lazy(() => import('../EditProfilePage'));
-const ChangePasswordPage = lazy(() => import('../ChangePasswordPage'));
 const RegisterAppPage = lazy(() => import('../RegisterAppPage'));
 const SignInPage = lazy(() => import('../AccountPage/SignIn'));
 const SignUpPage = lazy(() => import('../AccountPage/SignUp'));


### PR DESCRIPTION
비밀번호 변경페이지 컴포넌트를 담고있는 changePasswordPage 변수는
현재 사용되지 않기 때문에 삭제.